### PR TITLE
✨ Add shared reusable workflows, templates, and sync job

### DIFF
--- a/.github/workflows/reusable-md-link-check.yml
+++ b/.github/workflows/reusable-md-link-check.yml
@@ -1,0 +1,44 @@
+# Reusable Markdown Link Check workflow
+# Validates links in markdown files using lychee
+#
+# Usage in consuming repo:
+#   name: Markdown Link Check
+#   on:
+#     push:
+#       branches: [main]
+#     pull_request:
+#       branches: [main]
+#     workflow_dispatch:
+#   jobs:
+#     links:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main
+
+name: Markdown Link Check (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      config-file:
+        description: 'Path to lychee config file (optional)'
+        required: false
+        type: string
+        default: ''
+      args:
+        description: 'Additional lychee arguments'
+        required: false
+        type: string
+        default: '--verbose --no-progress **/*.md'
+
+jobs:
+  lychee:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@v2.7.0
+        with:
+          args: '${{ inputs.config-file != '''' && format(''--config {0} '', inputs.config-file) || '''' }}${{ inputs.args }}'
+          fail: true

--- a/.github/workflows/reusable-non-main-gatekeeper.yml
+++ b/.github/workflows/reusable-non-main-gatekeeper.yml
@@ -1,0 +1,28 @@
+# Reusable Non-Main Gatekeeper workflow
+# Adds 'do-not-merge/hold' label to PRs targeting non-main branches
+#
+# Usage in consuming repo:
+#   name: Non-Main Gatekeeper
+#   on:
+#     pull_request:
+#       types: [opened, edited, synchronize, reopened]
+#   jobs:
+#     gatekeeper:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main
+
+name: Non-Main Gatekeeper (Reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add hold label when base branch is not main
+        if: github.event.pull_request.base.ref != 'main'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            do-not-merge/hold

--- a/.github/workflows/reusable-prow-automerge.yml
+++ b/.github/workflows/reusable-prow-automerge.yml
@@ -1,0 +1,32 @@
+# Reusable Prow Auto-merge workflow
+# Auto-merges PRs with the 'lgtm' label (blocked by 'hold' label)
+#
+# Usage in consuming repo:
+#   name: Prow Auto-merge
+#   on:
+#     schedule:
+#       - cron: "*/5 * * * *"
+#   jobs:
+#     auto-merge:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main
+
+name: Prow Auto-merge (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      merge-method:
+        description: 'Merge method: squash, merge, or rebase'
+        required: false
+        type: string
+        default: 'squash'
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: 'lgtm'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          merge-method: "${{ inputs.merge-method }}"

--- a/.github/workflows/reusable-prow-commands.yml
+++ b/.github/workflows/reusable-prow-commands.yml
@@ -1,0 +1,54 @@
+# Reusable Prow Commands workflow
+# Handles /assign, /lgtm, /approve, /hold, etc. on issue/PR comments
+#
+# Usage in consuming repo:
+#   name: Prow Commands
+#   on:
+#     issue_comment:
+#       types: [created]
+#   jobs:
+#     prow:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
+#       permissions:
+#         issues: write
+#         pull-requests: write
+
+name: Prow Commands (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      prow-commands:
+        description: 'Newline-separated list of prow commands to enable'
+        required: false
+        type: string
+        default: |
+          /assign
+          /unassign
+          /approve
+          /retitle
+          /area
+          /kind
+          /priority
+          /remove
+          /lgtm
+          /close
+          /reopen
+          /lock
+          /milestone
+          /hold
+          /cc
+          /uncc
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  prow-execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          prow-commands: "${{ inputs.prow-commands }}"

--- a/.github/workflows/reusable-prow-remove-lgtm.yml
+++ b/.github/workflows/reusable-prow-remove-lgtm.yml
@@ -1,0 +1,23 @@
+# Reusable Prow Remove LGTM workflow
+# Removes the 'lgtm' label when a PR is updated
+#
+# Usage in consuming repo:
+#   name: Prow Remove LGTM
+#   on: pull_request
+#   jobs:
+#     remove-lgtm:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main
+
+name: Prow Remove LGTM (Reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/reusable-signed-commits.yml
+++ b/.github/workflows/reusable-signed-commits.yml
@@ -1,0 +1,34 @@
+# Reusable Signed Commits Check workflow
+# Enforces DCO/signed commits on pull requests
+#
+# Usage in consuming repo:
+#   name: Check Signed Commits
+#   on: pull_request_target
+#   jobs:
+#     signed-commits:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+#       permissions:
+#         contents: read
+#         pull-requests: write
+
+name: Signed Commits Check (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1
+        with:
+          comment: |
+            Unsigned commits detected! Please sign your commits.
+
+            For instructions on how to set up GPG/SSH signing and verify your commits, please see [GitHub Documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification).

--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -1,0 +1,80 @@
+# Reusable Stale Issues/PRs workflow
+# Marks issues stale after 90d, rotten after 15d more, closed after 15d more
+# Marks PRs stale after 21d, rotten after 7d more, closed after 7d more
+#
+# Usage in consuming repo:
+#   name: Mark Stale Issues
+#   on:
+#     schedule:
+#       - cron: '0 1 * * *'
+#   jobs:
+#     stale:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+#       permissions:
+#         issues: write
+#         pull-requests: write
+
+name: Stale Issues (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      days-before-issue-stale:
+        description: 'Days before marking issues stale'
+        required: false
+        type: number
+        default: 90
+      days-before-pr-stale:
+        description: 'Days before marking PRs stale'
+        required: false
+        type: number
+        default: 21
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v10
+        with:
+          days-before-issue-stale: ${{ inputs.days-before-issue-stale }}
+          days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
+          days-before-close: -1
+          stale-issue-label: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/rotten'
+          stale-issue-message: >-
+            This issue is marked as stale after ${{ inputs.days-before-issue-stale }}d of inactivity.
+            After an additional 30d of inactivity (15d to become rotten, then 15d more), it will be closed.
+            To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.
+          stale-pr-label: 'lifecycle/stale'
+          exempt-pr-labels: 'lifecycle/rotten'
+          stale-pr-message: >-
+            This PR is marked as stale after ${{ inputs.days-before-pr-stale }}d of inactivity.
+            After an additional 14d of inactivity (7d to become rotten, then 7d more), it will be closed.
+            To prevent this PR from being closed, add a comment or remove the `lifecycle/stale` label.
+
+      - name: Mark items rotten
+        uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 15
+          days-before-pr-stale: 7
+          days-before-close: -1
+          stale-issue-label: 'lifecycle/rotten'
+          stale-pr-label: 'lifecycle/rotten'
+          only-labels: 'lifecycle/stale'
+          labels-to-remove-when-stale: 'lifecycle/stale'
+
+      - name: Close rotten items
+        uses: actions/stale@v10
+        with:
+          days-before-stale: -1
+          days-before-issue-close: 15
+          days-before-pr-close: 7
+          stale-issue-label: 'lifecycle/rotten'
+          stale-issue-message: 'This issue is being closed after extended inactivity.'
+          stale-pr-label: 'lifecycle/rotten'
+          stale-pr-message: 'This PR is being closed after extended inactivity.'

--- a/.github/workflows/reusable-typos.yml
+++ b/.github/workflows/reusable-typos.yml
@@ -1,0 +1,26 @@
+# Reusable Typos Check workflow
+# Spell-checks code and documentation
+#
+# Usage in consuming repo:
+#   name: Check Typos
+#   on:
+#     pull_request:
+#     push:
+#   jobs:
+#     typos:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main
+
+name: Typos Check (Reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check typos
+        uses: crate-ci/typos@v1.43.0

--- a/.github/workflows/reusable-unstale.yml
+++ b/.github/workflows/reusable-unstale.yml
@@ -1,0 +1,41 @@
+# Reusable Unstale workflow
+# Removes lifecycle/stale and lifecycle/rotten labels when issues get activity
+#
+# Usage in consuming repo:
+#   name: Unstale Issues
+#   on:
+#     issues:
+#       types: [reopened]
+#     issue_comment:
+#       types: [created]
+#   jobs:
+#     unstale:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+#       permissions:
+#         issues: write
+
+name: Unstale Issues (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  issues: write
+
+jobs:
+  remove-stale:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.state == 'open' &&
+      (contains(github.event.issue.labels.*.name, 'lifecycle/stale') ||
+       contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Remove stale labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Removing 'stale' label from issue #${{ github.event.issue.number }}"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "lifecycle/stale,lifecycle/rotten"

--- a/.github/workflows/sync-caller-workflows.yml
+++ b/.github/workflows/sync-caller-workflows.yml
@@ -1,0 +1,83 @@
+# Sync Caller Workflows
+# When reusable workflows change, report which consuming repos still use
+# local copies and need migration.
+#
+# Runs on push to main (when reusable-*.yml changes) or manual dispatch.
+
+name: Sync Caller Workflows to Consuming Repos
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/reusable-*.yml'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview changes without opening PRs'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  CONSUMING_REPOS: |
+    llm-d/llm-d
+    llm-d/llm-d-inference-scheduler
+    llm-d/llm-d-kv-cache
+    llm-d/llm-d-inference-sim
+    llm-d/llm-d-benchmark
+    llm-d/llm-d-workload-variant-autoscaler
+
+jobs:
+  check-adoption:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout infra repo
+        uses: actions/checkout@v6
+
+      - name: Check adoption status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "## Reusable Workflow Adoption Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repo | Workflow | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          # Map reusable workflows to their expected caller filenames
+          declare -A WORKFLOW_MAP=(
+            ["reusable-prow-commands.yml"]="prow-github.yml"
+            ["reusable-prow-automerge.yml"]="prow-pr-automerge.yml"
+            ["reusable-prow-remove-lgtm.yml"]="prow-pr-remove-lgtm.yml"
+            ["reusable-stale.yml"]="stale.yaml"
+            ["reusable-unstale.yml"]="unstale.yaml"
+            ["reusable-signed-commits.yml"]="ci-signed-commits.yaml"
+            ["reusable-typos.yml"]="check-typos.yaml"
+            ["reusable-md-link-check.yml"]="md-link-check.yml"
+            ["reusable-non-main-gatekeeper.yml"]="non-main-gatekeeper.yml"
+          )
+
+          while IFS= read -r repo; do
+            [ -z "$repo" ] && continue
+            for reusable in "${!WORKFLOW_MAP[@]}"; do
+              caller="${WORKFLOW_MAP[$reusable]}"
+              # Check if workflow exists in the target repo
+              content=$(gh api "repos/$repo/contents/.github/workflows/$caller" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+              if [ -z "$content" ]; then
+                continue  # workflow doesn't exist in this repo
+              fi
+              if echo "$content" | grep -q "llm-d/llm-d-infra"; then
+                echo "| $repo | $caller | Adopted |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| $repo | $caller | **Local copy** |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done
+          done <<< "$CONSUMING_REPOS"
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Repos using **Local copy** should migrate to the shared reusable workflow." >> "$GITHUB_STEP_SUMMARY"
+          echo "See [migration instructions](https://github.com/llm-d/llm-d-infra#migrating-existing-repos)." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,169 @@
 # llm-d-infra
-repo for CI and infrastructure required to maintain llm-d org member repos
+
+Repo for CI and infrastructure required to maintain llm-d org member repos.
+
+## Reusable Workflows
+
+This repo provides [reusable GitHub Actions workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) that standardize CI/CD across all llm-d repos. Instead of copy-pasting workflow files, each repo calls the shared version with a thin caller workflow.
+
+### Available Workflows
+
+| Workflow | Purpose | Caller Trigger |
+|----------|---------|----------------|
+| `reusable-prow-commands.yml` | Prow-style commands (/lgtm, /approve, /assign, etc.) | `issue_comment` |
+| `reusable-prow-automerge.yml` | Auto-merge PRs with `lgtm` label | `schedule` (every 5 min) |
+| `reusable-prow-remove-lgtm.yml` | Remove `lgtm` label on PR push | `pull_request` |
+| `reusable-stale.yml` | Mark stale issues/PRs, then rotten, then close | `schedule` (daily) |
+| `reusable-unstale.yml` | Remove stale/rotten labels on activity | `issues` + `issue_comment` |
+| `reusable-signed-commits.yml` | Enforce signed/DCO commits | `pull_request_target` |
+| `reusable-typos.yml` | Spell-check code and docs | `pull_request` + `push` |
+| `reusable-md-link-check.yml` | Validate markdown links with lychee | `push` + `pull_request` |
+| `reusable-non-main-gatekeeper.yml` | Block PRs to non-main branches | `pull_request` |
+
+### Usage
+
+Create a thin caller workflow in your repo's `.github/workflows/` directory. Each caller is typically 8-12 lines:
+
+```yaml
+# .github/workflows/prow-github.yml
+name: Prow Commands
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+```
+
+```yaml
+# .github/workflows/prow-pr-automerge.yml
+name: Prow Auto-merge
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+jobs:
+  auto-merge:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main
+```
+
+```yaml
+# .github/workflows/prow-pr-remove-lgtm.yml
+name: Prow Remove LGTM
+on: pull_request
+jobs:
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main
+```
+
+```yaml
+# .github/workflows/stale.yaml
+name: Mark Stale Issues
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+```
+
+```yaml
+# .github/workflows/unstale.yaml
+name: Unstale Issues
+on:
+  issues:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+jobs:
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+    permissions:
+      issues: write
+```
+
+```yaml
+# .github/workflows/ci-signed-commits.yaml
+name: Check Signed Commits
+on: pull_request_target
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+```
+
+```yaml
+# .github/workflows/check-typos.yaml
+name: Check Typos
+on:
+  pull_request:
+  push:
+jobs:
+  typos:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main
+```
+
+```yaml
+# .github/workflows/md-link-check.yml
+name: Markdown Link Check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  links:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main
+```
+
+```yaml
+# .github/workflows/non-main-gatekeeper.yml
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main
+```
+
+### Customization
+
+Most workflows accept optional inputs. See each workflow file for available inputs and defaults:
+
+```yaml
+jobs:
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    with:
+      days-before-issue-stale: 60  # override default of 90
+```
+
+## Templates
+
+The `templates/` directory contains canonical configuration files for adoption across repos:
+
+| Template | Purpose | Copy To |
+|----------|---------|---------|
+| `dependabot.yml` | Automated dependency updates for Go, Actions, Docker | `.github/dependabot.yml` |
+| `.pre-commit-config.yaml` | File hygiene, shell/Dockerfile/markdown/YAML linting | repo root |
+
+## Migrating Existing Repos
+
+To migrate from copy-pasted workflows to shared reusable ones:
+
+1. Replace each local workflow file with the corresponding thin caller (see examples above)
+2. Remove any duplicate logic now handled by the reusable workflow
+3. Test by opening a PR and verifying workflows trigger correctly
+
+## Sync Workflow
+
+The `sync-caller-workflows.yml` checks which consuming repos still use local copies vs. shared reusable workflows. It runs when reusable workflows change and generates an adoption report in the workflow summary.

--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+# Canonical pre-commit configuration for llm-d repos
+# Copy this file to the root of your repo
+#
+# Install: pip install pre-commit && pre-commit install
+# Run all: pre-commit run --all-files
+
+repos:
+  # General file hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # allows custom YAML tags used in k8s
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-case-conflict
+
+  # Shell script linting (requires shellcheck installed)
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        args: [-x, --severity=warning]
+        types: [shell]
+
+  # Dockerfile linting (requires hadolint installed)
+  - repo: local
+    hooks:
+      - id: hadolint-docker
+        name: hadolint
+        language: system
+        entry: hadolint
+        args: [--failure-threshold, error]
+        files: Dockerfile.*
+        types: [file]
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args:
+          - -d
+          - >-
+            {extends: default, rules: {line-length: {max: 250},
+            document-start: disable, truthy: {check-keys: false}}}

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,0 +1,71 @@
+# Canonical Dependabot configuration for llm-d repos
+# Copy this file to .github/dependabot.yml in your repo
+#
+# Covers: Go modules, GitHub Actions, Docker base images
+# Remove sections that don't apply to your repo
+
+version: 2
+updates:
+
+  # Go module updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(go)"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    ignore:
+      # Ignore major and minor updates to Go toolchain
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major and minor version updates to k8s packages
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major updates for all packages
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Python dependencies (uncomment if repo uses pip/requirements.txt)
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels:
+  #     - "dependencies"
+  #   commit-message:
+  #     prefix: "deps(pip)"


### PR DESCRIPTION
## Summary

- Adds 9 reusable GitHub Actions workflows to standardize CI/CD across all llm-d repos, eliminating identical copy-pasted workflows (Prow alone is duplicated in 6+ repos)
- Adds canonical templates for `dependabot.yml` and `.pre-commit-config.yaml` that repos can adopt
- Adds a sync workflow that reports which consuming repos have migrated vs. still use local copies

## Reusable Workflows

| Workflow | Replaces |
|----------|----------|
| `reusable-prow-commands.yml` | `prow-github.yml` across 6 repos |
| `reusable-prow-automerge.yml` | `prow-pr-automerge.yml` across 6 repos |
| `reusable-prow-remove-lgtm.yml` | `prow-pr-remove-lgtm.yml` across 6 repos |
| `reusable-stale.yml` | `stale.yaml` in inference-scheduler, inference-sim |
| `reusable-unstale.yml` | `unstale.yaml` in inference-scheduler, inference-sim |
| `reusable-signed-commits.yml` | `ci-signed-commits.yaml` in inference-scheduler |
| `reusable-typos.yml` | `check-typos.yaml` in inference-scheduler |
| `reusable-md-link-check.yml` | `md-link-check.yml` across 4+ repos |
| `reusable-non-main-gatekeeper.yml` | `non-main-gatekeeper.yml` in inference-scheduler |

## How It Works

Each consuming repo replaces its local workflow with a thin caller (~8-12 lines) that references the shared version:

```yaml
name: Prow Commands
on:
  issue_comment:
    types: [created]
jobs:
  prow:
    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main
    permissions:
      issues: write
      pull-requests: write
```

## Test Plan

- [ ] Verify reusable workflows have valid YAML syntax
- [ ] After merge, create a test caller workflow in a fork to verify cross-repo `workflow_call` works
- [ ] Review README for completeness of migration instructions
- [ ] Verify sync workflow reports adoption status correctly