### PR TITLE
🐛 Fix hadolint files regex in pre-commit template

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         language: system
         entry: hadolint
         args: [--failure-threshold, error]
-        files: Dockerfile.*
+        files: Dockerfile(\\..*)?$
         types: [file]
 
   # Markdown linting


### PR DESCRIPTION
## Summary
- Fix hadolint `files` regex from `Dockerfile.*` to `Dockerfile(\\..*)?$` so it matches bare `Dockerfile` (not just `Dockerfile.something`)
- Reported by Copilot code review on downstream PRs

## Test plan
- [ ] Verify `Dockerfile` (no extension) is linted by hadolint
- [ ] Verify `Dockerfile.epp`, `Dockerfile.sidecar` etc. still match