### PR TITLE
🌱 Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot configuration for llm-d-infra
+# Based on canonical config from llm-d/llm-d-infra
+
+version: 2
+updates:
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -31,13 +31,13 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      go-dependencies:
-        patterns:
-          - "*"
       kubernetes:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      go-dependencies:
+        patterns:
+          - "*"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Add Dependabot config to track GitHub Actions version updates on a weekly schedule

## Test plan
- [ ] Verify Dependabot creates dependency update PRs on schedule

cc @diegocastanibm @maugustosilva