### PR TITLE
🐛 Fix nightly E2E failure from orphaned cluster-scoped WVA resources

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -284,6 +284,23 @@ jobs:
             -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
             --ignore-not-found || true
 
+          # Clean up orphaned cluster-scoped WVA resources from ANY release
+          # whose owning namespace no longer exists. These block fresh installs
+          # because Helm refuses to adopt resources owned by a different release.
+          # Safety: only deletes resources whose release-namespace is gone — active
+          # installations (where the namespace still exists) are never touched.
+          echo "Checking for orphaned cluster-scoped WVA resources..."
+          for kind in clusterrole clusterrolebinding; do
+            for resource in $(kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\.helm\.sh/release-namespace}{"\n"}{end}' 2>/dev/null); do
+              name="${resource%%=*}"
+              ns="${resource##*=}"
+              if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
+                echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
+                kubectl delete "$kind" "$name" --ignore-not-found || true
+              fi
+            done
+          done
+
           echo "Pre-cleanup complete"
 
       - name: Apply latest CRDs
@@ -410,9 +427,22 @@ jobs:
           echo "Deleting namespace $WVA_NAMESPACE..."
           kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || true
 
-          # Clean up cluster-scoped WVA resources
+          # Clean up cluster-scoped WVA resources owned by this nightly's release
           kubectl delete clusterrole,clusterrolebinding \
             -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
             --ignore-not-found || true
+
+          # Also clean up cluster-scoped resources owned by the nightly namespaces
+          # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
+          for kind in clusterrole clusterrolebinding; do
+            for resource in $(kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\.helm\.sh/release-namespace}{"\n"}{end}' 2>/dev/null); do
+              name="${resource%%=*}"
+              ns="${resource##*=}"
+              if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
+                kubectl delete "$kind" "$name" --ignore-not-found || true
+              fi
+            done
+          done
 
           echo "Nightly cleanup complete"


### PR DESCRIPTION
## Summary
- Nightly E2E fails at "Deploy infrastructure" when a stale ClusterRole from a previous WVA installation blocks the helmfile deploy
- The orphaned ClusterRole has `meta.helm.sh/release-namespace` pointing to a namespace that no longer exists (`llm-d-autoscaler`), so Helm refuses to adopt it
- **Pre-cleanup**: Detect and delete orphaned WVA ClusterRoles/ClusterRoleBindings whose owning namespace no longer exists (active installations are never touched)
- **Post-cleanup**: Also delete cluster-scoped resources owned by the nightly's own namespaces (covers helmfile-created resources with different instance labels)

## Root Cause
```
Error: Unable to continue with install: ClusterRole "workload-variant-autoscaler-metrics-auth-role"
exists and cannot be imported into the current release: invalid ownership metadata;
key "meta.helm.sh/release-namespace" must equal "llm-d-nightly-wva": current value is "llm-d-autoscaler"
```

A previous WVA installation's namespace was deleted but its cluster-scoped resources were left behind. The existing cleanup only matches by `app.kubernetes.io/instance=<WVA_RELEASE_NAME>`, which doesn't cover resources created by the helmfile's WVA sub-chart (different release name/instance label).

## Safety
- **Pre-cleanup orphan detection**: Only deletes resources whose `meta.helm.sh/release-namespace` references a namespace that **no longer exists**. If the namespace exists, the resource is left alone.
- **Post-cleanup**: Only deletes resources owned by the nightly's own namespaces (`$LLMD_NAMESPACE` or `$WVA_NAMESPACE`), which are being deleted anyway.
- All deletes use `--ignore-not-found` and `|| true` to avoid blocking on errors.

## Test plan
- [ ] Re-run the WVA nightly E2E after merging — the orphaned ClusterRole from `llm-d-autoscaler` will be detected and cleaned up before deploy
- [ ] Verify other WVA installations on the cluster are not affected
- [ ] Verify post-cleanup properly removes cluster-scoped resources