### PR TITLE
🐛 Fix jsonpath annotation parsing in orphan cleanup

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -291,14 +291,15 @@ jobs:
           # installations (where the namespace still exists) are never touched.
           echo "Checking for orphaned cluster-scoped WVA resources..."
           for kind in clusterrole clusterrolebinding; do
-            for resource in $(kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\.helm\.sh/release-namespace}{"\n"}{end}' 2>/dev/null); do
-              name="${resource%%=*}"
-              ns="${resource##*=}"
-              if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
-                echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
-                kubectl delete "$kind" "$name" --ignore-not-found || true
-              fi
-            done
+            # Use jq to reliably extract annotation keys containing dots/slashes
+            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
+              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+              while IFS=$'\t' read -r name ns; do
+                if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
+                  echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
+                  kubectl delete "$kind" "$name" --ignore-not-found || true
+                fi
+              done
           done
 
           echo "Pre-cleanup complete"
@@ -435,14 +436,14 @@ jobs:
           # Also clean up cluster-scoped resources owned by the nightly namespaces
           # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
           for kind in clusterrole clusterrolebinding; do
-            for resource in $(kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.annotations.meta\.helm\.sh/release-namespace}{"\n"}{end}' 2>/dev/null); do
-              name="${resource%%=*}"
-              ns="${resource##*=}"
-              if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
-                echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
-                kubectl delete "$kind" "$name" --ignore-not-found || true
-              fi
-            done
+            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
+              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+              while IFS=$'\t' read -r name ns; do
+                if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                  echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
+                  kubectl delete "$kind" "$name" --ignore-not-found || true
+                fi
+              done
           done
 
           echo "Nightly cleanup complete"


### PR DESCRIPTION
## Summary
- Switch from `kubectl jsonpath` to `jq` for extracting Helm annotations with dots/slashes in key names (`meta.helm.sh/release-namespace`)
- `jsonpath` silently returns empty results for these annotation keys, causing orphan detection to miss stale ClusterRoles
- `jq` with bracket notation (`["meta.helm.sh/release-namespace"]`) handles these keys correctly

Fixes both pre-cleanup (orphan detection) and post-cleanup (namespace-scoped deletion) in the reusable nightly E2E workflow.

Follow-up to PR #10 which introduced the orphan cleanup but used jsonpath.

## Test plan
- [ ] Trigger nightly E2E on WVA and verify orphaned ClusterRole is detected and deleted
- [ ] Verify the nightly run completes successfully through the Deploy infrastructure step