### PR TITLE
🐛 Fix orphan cleanup: search by name pattern instead of labels

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -291,9 +291,10 @@ jobs:
           # installations (where the namespace still exists) are never touched.
           echo "Checking for orphaned cluster-scoped WVA resources..."
           for kind in clusterrole clusterrolebinding; do
+            # Search by name pattern (not labels — helmfile deployments may use different labels)
             # Use jq to reliably extract annotation keys containing dots/slashes
-            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
-              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
               while IFS=$'\t' read -r name ns; do
                 if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
                   echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
@@ -436,8 +437,8 @@ jobs:
           # Also clean up cluster-scoped resources owned by the nightly namespaces
           # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
           for kind in clusterrole clusterrolebinding; do
-            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
-              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
               while IFS=$'\t' read -r name ns; do
                 if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
                   echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"


### PR DESCRIPTION
## Summary
- Orphaned ClusterRoles created by helmfile deployments don't have the `app.kubernetes.io/name=workload-variant-autoscaler` label
- The label-based `kubectl get` selector finds nothing, so orphans are never cleaned up
- Switch to listing all ClusterRoles/ClusterRoleBindings and filtering by name pattern (`contains("workload-variant-autoscaler")`) using `jq`
- Applies to both pre-cleanup (orphan detection) and post-cleanup (namespace-scoped deletion)

Follow-up to PR #11 (jq fix) and PR #10 (original orphan cleanup).

## Test plan
- [ ] Trigger nightly E2E on WVA and verify orphaned ClusterRole is detected and deleted
- [ ] Verify deploy infrastructure step succeeds