### PR TITLE
🐛 Set MONITORING_NAMESPACE for OpenShift nightly E2E

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -291,9 +291,10 @@ jobs:
           # installations (where the namespace still exists) are never touched.
           echo "Checking for orphaned cluster-scoped WVA resources..."
           for kind in clusterrole clusterrolebinding; do
+            # Search by name pattern (not labels — helmfile deployments may use different labels)
             # Use jq to reliably extract annotation keys containing dots/slashes
-            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
-              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
               while IFS=$'\t' read -r name ns; do
                 if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
                   echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
@@ -329,6 +330,8 @@ jobs:
           DEPLOY_PROMETHEUS_ADAPTER: ${{ inputs.deploy_wva && 'true' || 'false' }}
           DEPLOY_VA: ${{ inputs.deploy_wva && 'true' || 'false' }}
           DEPLOY_HPA: ${{ inputs.deploy_wva && 'true' || 'false' }}
+          # OpenShift uses built-in user-workload monitoring, not a separate namespace
+          MONITORING_NAMESPACE: openshift-user-workload-monitoring
         run: |
           echo "Deploying infrastructure for guide: $GUIDE_NAME (nightly)..."
           echo "  MODEL_ID: $MODEL_ID"
@@ -436,8 +439,8 @@ jobs:
           # Also clean up cluster-scoped resources owned by the nightly namespaces
           # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
           for kind in clusterrole clusterrolebinding; do
-            kubectl get "$kind" -l app.kubernetes.io/name=workload-variant-autoscaler -o json 2>/dev/null | \
-              jq -r '.items[] | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+            kubectl get "$kind" -o json 2>/dev/null | \
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
               while IFS=$'\t' read -r name ns; do
                 if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
                   echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"


### PR DESCRIPTION
## Summary
- The llm-d helmfile's `workload-autoscaling/values.yaml` defaults `monitoringNamespace` to `llm-d-monitoring` (for KIND clusters)
- On OpenShift, the monitoring namespace is `openshift-user-workload-monitoring`
- The install.sh script overrides this for the direct `helm upgrade` WVA install, but NOT for the helmfile-deployed WVA release
- This causes `namespaces "llm-d-monitoring" not found` during helmfile apply
- Fix: explicitly set `MONITORING_NAMESPACE=openshift-user-workload-monitoring` in the Deploy infrastructure step env

## Test plan
- [ ] Trigger nightly E2E and verify Deploy infrastructure step passes