### PR TITLE
🐛 Adopt shared WVA ClusterRoles before helmfile deploy

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -284,21 +284,23 @@ jobs:
             -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
             --ignore-not-found || true
 
-          # Clean up orphaned cluster-scoped WVA resources from ANY release
-          # whose owning namespace no longer exists. These block fresh installs
-          # because Helm refuses to adopt resources owned by a different release.
-          # Safety: only deletes resources whose release-namespace is gone — active
-          # installations (where the namespace still exists) are never touched.
-          echo "Checking for orphaned cluster-scoped WVA resources..."
+          # The helmfile uses a generic release name "workload-variant-autoscaler" which
+          # produces non-unique ClusterRole names. On shared clusters, these resources
+          # may be owned by another namespace's release, causing Helm ownership conflicts.
+          # Fix: adopt them for our namespace so helmfile can proceed. Post-cleanup will
+          # delete them, and the next user's helmfile run will recreate them fresh.
+          echo "Adopting shared WVA cluster-scoped resources for namespace $LLMD_NAMESPACE..."
           for kind in clusterrole clusterrolebinding; do
-            # Search by name pattern (not labels — helmfile deployments may use different labels)
-            # Use jq to reliably extract annotation keys containing dots/slashes
             kubectl get "$kind" -o json 2>/dev/null | \
-              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-              while IFS=$'\t' read -r name ns; do
-                if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
-                  echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
-                  kubectl delete "$kind" "$name" --ignore-not-found || true
+              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | select(.metadata.annotations["meta.helm.sh/release-namespace"] != null) | .metadata.name' 2>/dev/null | \
+              while read -r name; do
+                current_ns=$(kubectl get "$kind" "$name" -o json 2>/dev/null | jq -r '.metadata.annotations["meta.helm.sh/release-namespace"] // ""')
+                if [ "$current_ns" != "$LLMD_NAMESPACE" ]; then
+                  echo "  Adopting $kind/$name (was owned by '$current_ns')"
+                  kubectl annotate "$kind" "$name" \
+                    "meta.helm.sh/release-name=workload-variant-autoscaler" \
+                    "meta.helm.sh/release-namespace=$LLMD_NAMESPACE" \
+                    --overwrite || true
                 fi
               done
           done


### PR DESCRIPTION
## Summary
- The helmfile uses release name `workload-variant-autoscaler` which produces **non-unique** ClusterRole names (`workload-variant-autoscaler-metrics-auth-role`, etc.)
- On shared clusters, these may be owned by another namespace's active release (e.g. `llm-d-vezio`)
- Previous fix (PR #12) only cleaned up **orphaned** resources (deleted namespaces), but not resources owned by active namespaces
- New approach: **adopt** the shared resources by patching their `meta.helm.sh/release-namespace` annotation to our nightly namespace
- Post-cleanup deletes them after testing, and the next user's helmfile run recreates them

This is a workaround for a chart design issue — the ClusterRole names should include the release name to be unique. Filed as a known issue.

## Test plan
- [ ] Trigger nightly E2E and verify Deploy infrastructure succeeds
- [ ] Verify post-cleanup removes the adopted resources