### PR TITLE
🐛 Fix deployment name mismatch in nightly E2E

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -324,6 +324,9 @@ jobs:
           VLLM_MAX_NUM_SEQS: ${{ inputs.max_num_seqs }}
           DECODE_REPLICAS: "1"
           WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
+          # Align helmfile release name postfix with guide name so that
+          # deployment names (ms-<postfix>-llm-d-modelservice-decode) are predictable
+          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
           # WVA deployment flag — only deploy WVA for workload-autoscaling guide
           DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || 'false' }}
           DEPLOY_PROMETHEUS: ${{ inputs.deploy_wva && 'true' || 'false' }}


### PR DESCRIPTION
## Summary
- Sets `RELEASE_NAME_POSTFIX` to match `guide_name` in the Deploy infrastructure step
- Fixes deployment name mismatch: helmfile creates `ms-workload-autoscaler-*` but E2E tests look for `ms-workload-autoscaling-*`

## Problem
The helmfile's `$rn` variable defaults to `workload-autoscaler` (from `RELEASE_NAME_POSTFIX`), producing releases like `ms-workload-autoscaler`. The E2E test derives the deployment name from `guide_name` (`workload-autoscaling`), looking for `ms-workload-autoscaling-llm-d-modelservice-decode`. This mismatch causes the BeforeSuite to time out (300s) waiting for a deployment that doesn't exist under that name.

## Test plan
- [ ] Trigger nightly from WVA branch — verify DEPLOYMENT matches actual deployment name
- [ ] E2E BeforeSuite should find the decode deployment and proceed to tests