### PR TITLE
🐛 Pass --namespace to helmfile in nightly E2E workflows

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -256,7 +256,7 @@ jobs:
             if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
               echo "  Destroying helmfile releases..."
               cd "$GUIDE_PATH"
-              helmfile destroy -e "$HELMFILE_ENV" --args --ignore-not-found 2>/dev/null || true
+              helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" --args --ignore-not-found 2>/dev/null || true
               cd "$GITHUB_WORKSPACE"
             fi
 
@@ -301,6 +301,7 @@ jobs:
           echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
           cd "$GUIDE_PATH"
           helmfile apply -e "$HELMFILE_ENV" \
+            --namespace "$NAMESPACE" \
             --set "gateway.service.type=LoadBalancer" \
             --skip-schema-validation \
             ${{ inputs.helmfile_args }} \
@@ -465,7 +466,7 @@ jobs:
           if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
             echo "Destroying helmfile releases..."
             cd "$GUIDE_PATH"
-            helmfile destroy -e "$HELMFILE_ENV" 2>/dev/null || true
+            helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" 2>/dev/null || true
             cd "$GITHUB_WORKSPACE"
           fi
 

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -256,7 +256,7 @@ jobs:
             if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
               echo "  Destroying helmfile releases..."
               cd "$GUIDE_PATH"
-              helmfile destroy -e "$HELMFILE_ENV" --args --ignore-not-found 2>/dev/null || true
+              helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" --args --ignore-not-found 2>/dev/null || true
               cd "$GITHUB_WORKSPACE"
             fi
 
@@ -326,6 +326,7 @@ jobs:
           echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
           cd "$GUIDE_PATH"
           helmfile apply -e "$HELMFILE_ENV" \
+            --namespace "$NAMESPACE" \
             --skip-schema-validation \
             ${{ inputs.helmfile_args }} \
             | tee /tmp/helmfile-deploy.log
@@ -470,7 +471,7 @@ jobs:
           if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
             echo "Destroying helmfile releases..."
             cd "$GUIDE_PATH"
-            helmfile destroy -e "$HELMFILE_ENV" 2>/dev/null || true
+            helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" 2>/dev/null || true
             cd "$GITHUB_WORKSPACE"
           fi
 


### PR DESCRIPTION
## Summary
- Fix namespace mismatch in helmfile-based nightly E2E workflows
- All guide helmfiles use `.Namespace` with a guide-specific default (e.g., `llm-d-inference-scheduling`, `llm-d-precise`, `llm-d-sim`)
- Without `--namespace`, helmfile deploys to the guide's default namespace while the workflow creates and checks a different nightly namespace
- This causes all helmfile-based nightlies (both OCP and GKE) to fail with "no matching resources found"

## Changes
- Add `--namespace "$NAMESPACE"` to `helmfile apply` in both OCP and GKE reusable workflows
- Add `--namespace "$NAMESPACE"` to `helmfile destroy` in pre-cleanup and post-cleanup steps of both workflows

## Affected workflows
- `reusable-nightly-e2e-openshift-helmfile.yaml` (3 changes)
- `reusable-nightly-e2e-gke-helmfile.yaml` (3 changes)

## Test plan
- [ ] Trigger `workflow_dispatch` on `nightly-e2e-inference-scheduling` (OCP) — verify pods deploy to `llm-d-nightly-inference` not `llm-d-inference-scheduling`
- [ ] Trigger `workflow_dispatch` on `nightly-e2e-inference-scheduling-gke` (GKE) — verify same
- [ ] Verify cleanup step properly destroys resources in the nightly namespace