### PR TITLE
🌱 Steer OCP nightly E2E tests to pok-prod cluster

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -127,7 +127,7 @@ on:
 
 jobs:
   nightly-e2e:
-    runs-on: [self-hosted, openshift]
+    runs-on: [self-hosted, openshift, pok-prod]
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}
       GUIDE_PATH: ${{ inputs.guide_path || format('guides/{0}', inputs.guide_name) }}

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -114,7 +114,7 @@ on:
 
 jobs:
   nightly-e2e:
-    runs-on: [self-hosted, openshift]
+    runs-on: [self-hosted, openshift, pok-prod]
     env:
       MODEL_ID: ${{ inputs.model_id }}
       ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}


### PR DESCRIPTION
## Summary
- Steers all OpenShift nightly E2E tests to pok-prod cluster (96 GPUs) by adding `pok-prod` runner label
- Fixes GPU scarcity issues that caused tiered-prefix-cache and other tests to fail

## Changes
- `reusable-nightly-e2e-openshift-helmfile.yaml`: `runs-on: [self-hosted, openshift, pok-prod]`
- `reusable-nightly-e2e-openshift.yaml`: `runs-on: [self-hosted, openshift, pok-prod]`

## Context
pok-prod-sa has 96 GPUs available. ARC runners on pok-prod have been scaled to 10 replicas and labeled with `pok-prod`.

## Test plan
- [ ] After merge, trigger OCP nightlies and verify they land on pok-prod runners
- [ ] Verify GPU-heavy tests (tiered-prefix-cache, precise-prefix-cache) pass with adequate GPUs