### PR TITLE
🐛 Fix nightly WVA ClusterRole orphan cleanup and bump pod timeout to 30m

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -123,7 +123,7 @@ on:
         description: 'Timeout for pods to become ready'
         required: false
         type: string
-        default: '15m'
+        default: '30m'
       pod_readiness_delay:
         description: 'Extra delay after pods are ready (for model loading)'
         required: false

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -111,7 +111,7 @@ on:
         description: 'Timeout for pods to become ready'
         required: false
         type: string
-        default: '15m'
+        default: '30m'
       pod_readiness_delay:
         description: 'Extra delay after pods are ready (for model loading)'
         required: false

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -284,15 +284,13 @@ jobs:
             -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
             --ignore-not-found || true
 
-          # Clean up orphaned cluster-scoped WVA resources from ANY release
-          # whose owning namespace no longer exists. These block fresh installs
-          # because Helm refuses to adopt resources owned by a different release.
-          # Safety: only deletes resources whose release-namespace is gone — active
-          # installations (where the namespace still exists) are never touched.
-          echo "Checking for orphaned cluster-scoped WVA resources..."
+          # Clean up orphaned cluster-scoped WVA resources whose owning
+          # namespace no longer exists. These block fresh installs because
+          # Helm refuses to adopt resources owned by a different release.
+          # Only deletes resources whose release-namespace is gone — active
+          # installations are never touched.
+          echo "Cleaning up orphaned cluster-scoped WVA resources..."
           for kind in clusterrole clusterrolebinding; do
-            # Search by name pattern (not labels — helmfile deployments may use different labels)
-            # Use jq to reliably extract annotation keys containing dots/slashes
             kubectl get "$kind" -o json 2>/dev/null | \
               jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
               while IFS=$'\t' read -r name ns; do


### PR DESCRIPTION
## Summary
- Bump default `pod_wait_timeout` from 15m to 30m in OCP and GKE helmfile workflows — large models (Qwen3-32B) need more time to load
- Restore orphaned ClusterRole cleanup in WVA workflow — only deletes WVA cluster-scoped resources whose owning namespace no longer exists (safe for active installations)

## Changes
- `reusable-nightly-e2e-openshift-helmfile.yaml`: pod_wait_timeout default 15m → 30m
- `reusable-nightly-e2e-gke-helmfile.yaml`: pod_wait_timeout default 15m → 30m
- `reusable-nightly-e2e-openshift.yaml`: restore orphan-only cleanup (no interference with other namespaces)

## Test plan
- [ ] Trigger WVA nightly after merge — verify ClusterRole cleanup works
- [ ] Trigger prefix-cache nightlies — verify 30m timeout gives pods enough time to load