### PR TITLE
✨ Add metrics pipeline diagnostics to nightly E2E workflow

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -367,6 +367,55 @@ jobs:
             kubectl get pods -n "$WVA_NAMESPACE"
           fi
 
+      - name: Verify metrics pipeline
+        if: inputs.deploy_wva
+        env:
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+        run: |
+          echo "=== Metrics Pipeline Verification ==="
+          echo ""
+
+          # Give the model time to load and start emitting metrics
+          echo "Waiting 180s for model to load and metrics to flow..."
+          sleep 180
+
+          echo ""
+          echo "--- VariantAutoscaling Status ---"
+          kubectl get variantautoscaling -n "$LLMD_NAMESPACE" -o wide || true
+          echo ""
+          kubectl get variantautoscaling -n "$LLMD_NAMESPACE" -o jsonpath='{range .items[*]}VA: {.metadata.name}{"\n"}  MetricsAvailable: {range .status.conditions[?(@.type=="MetricsAvailable")]}{.status} ({.reason}: {.message}){end}{"\n"}  DesiredOptimizedAlloc: replicas={.status.desiredOptimizedAlloc.numReplicas}, accel={.status.desiredOptimizedAlloc.accelerator}{"\n"}{end}' 2>/dev/null || true
+
+          echo ""
+          echo "--- WVA Controller Logs (last 50 lines) ---"
+          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=50 --all-containers 2>/dev/null || echo "Could not retrieve WVA controller logs"
+
+          echo ""
+          echo "--- WVA Controller Error Logs ---"
+          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers 2>/dev/null | grep -iE "error|fail|panic|cannot|refused|timeout|unauthorized|forbidden|certificate" | tail -20 || echo "No error logs found"
+
+          echo ""
+          echo "--- External Metrics API ---"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.resources[].name' 2>/dev/null || echo "External metrics API not responding"
+          echo ""
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
+
+          echo ""
+          echo "--- Prometheus Adapter Logs (last 30 lines) ---"
+          kubectl logs -n openshift-user-workload-monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=30 2>/dev/null || echo "Could not retrieve Prometheus Adapter logs"
+
+          echo ""
+          echo "--- PodMonitors & ServiceMonitors ---"
+          kubectl get podmonitor,servicemonitor -n "$LLMD_NAMESPACE" 2>/dev/null || echo "No monitors found"
+          kubectl get podmonitor,servicemonitor -n "$CONTROLLER_NAMESPACE" 2>/dev/null || echo "No monitors found in controller namespace"
+
+          echo ""
+          echo "--- vLLM Pod Status ---"
+          kubectl get pods -n "$LLMD_NAMESPACE" -l app.kubernetes.io/component=decode -o wide 2>/dev/null || \
+            kubectl get pods -n "$LLMD_NAMESPACE" | grep -i "model\|decode\|vllm" || echo "No vLLM pods found"
+
+          echo ""
+          echo "=== Metrics Pipeline Verification Complete ==="
+
       - name: Install Go dependencies
         run: |
           if [ -f go.mod ]; then
@@ -392,6 +441,62 @@ jobs:
           echo "  NUM_PROMPTS: $NUM_PROMPTS"
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
           make ${{ inputs.test_target }}
+
+      - name: Diagnostic dump (on failure)
+        if: failure() && inputs.deploy_wva
+        env:
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+        run: |
+          echo "=== Post-Failure Diagnostic Dump ==="
+
+          echo ""
+          echo "--- VariantAutoscaling Full Status ---"
+          kubectl describe variantautoscaling -n "$LLMD_NAMESPACE" 2>/dev/null || echo "No VA found"
+
+          echo ""
+          echo "--- WVA Controller Logs (full) ---"
+          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers --tail=200 2>/dev/null || echo "Could not retrieve WVA controller logs"
+
+          echo ""
+          echo "--- Prometheus Adapter Logs (full) ---"
+          kubectl logs -n openshift-user-workload-monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=100 2>/dev/null || echo "Could not retrieve Prometheus Adapter logs"
+
+          echo ""
+          echo "--- External Metrics API ---"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.' || echo "External metrics API not responding"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas not available"
+
+          echo ""
+          echo "--- All Pods in Test Namespaces ---"
+          kubectl get pods -n "$LLMD_NAMESPACE" -o wide 2>/dev/null || true
+          kubectl get pods -n "$CONTROLLER_NAMESPACE" -o wide 2>/dev/null || true
+          kubectl get pods -n openshift-user-workload-monitoring 2>/dev/null | grep -E "prometheus-adapter|prometheus-user" || true
+
+          echo ""
+          echo "--- HPA Status ---"
+          kubectl get hpa -n "$LLMD_NAMESPACE" -o wide 2>/dev/null || echo "No HPAs found"
+          kubectl describe hpa -n "$LLMD_NAMESPACE" 2>/dev/null || true
+
+          echo ""
+          echo "--- vLLM Pod Logs (last 30 lines) ---"
+          VLLM_POD=$(kubectl get pods -n "$LLMD_NAMESPACE" -o name 2>/dev/null | grep -i "model\|decode" | head -1)
+          if [ -n "$VLLM_POD" ]; then
+            kubectl logs -n "$LLMD_NAMESPACE" "$VLLM_POD" --all-containers --tail=30 2>/dev/null || echo "Could not get vLLM logs"
+          else
+            echo "No vLLM pod found"
+          fi
+
+          echo ""
+          echo "--- Namespace Labels ---"
+          kubectl get namespace "$LLMD_NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null | jq '.' || true
+          kubectl get namespace "$CONTROLLER_NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null | jq '.' || true
+
+          echo ""
+          echo "--- WVA ConfigMap (Prometheus config) ---"
+          kubectl get configmap -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler -o yaml 2>/dev/null | grep -A5 "PROMETHEUS\|prometheus\|baseURL\|monitoringNamespace" || echo "No WVA ConfigMap found"
+
+          echo ""
+          echo "=== Diagnostic Dump Complete ==="
 
       - name: Nightly summary
         if: always()


### PR DESCRIPTION
## Summary
- Add **pre-test metrics verification** step that runs after infrastructure deploy but before E2E tests
  - Waits 180s for model loading and metrics flow
  - Checks VA status (MetricsAvailable condition)
  - Dumps WVA controller logs and error lines
  - Checks external metrics API
  - Checks Prometheus Adapter logs
  - Lists PodMonitors/ServiceMonitors
- Add **post-failure diagnostic dump** step (runs only on test failure)
  - Full VA describe, controller logs, adapter logs
  - HPA status, vLLM pod logs
  - WVA ConfigMap (Prometheus config)
  - Namespace labels

## Context
The WVA nightly E2E tests are failing because `DesiredOptimizedAlloc` never gets populated and `MetricsAvailable` stays `False`. The WVA controller appears to be running but can't get metrics from Prometheus. These diagnostics will reveal the exact failure point in the metrics pipeline.

## Test plan
- [ ] Trigger nightly from WVA pointing to this branch of llm-d-infra
- [ ] Verify diagnostic output appears in the logs
- [ ] Use diagnostic output to identify and fix the metrics pipeline issue