### PR TITLE
🐛 Disable WVA metrics auth for OpenShift nightly

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -333,6 +333,11 @@ jobs:
           DEPLOY_HPA: ${{ inputs.deploy_wva && 'true' || 'false' }}
           # OpenShift uses built-in user-workload monitoring, not a separate namespace
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
+          # Disable bearer token auth on WVA /metrics endpoint — OpenShift's
+          # user-workload-monitoring cannot authenticate with the controller-manager
+          # SA token (Token does not match server's copy). The endpoint is still
+          # only accessible within the cluster network.
+          WVA_METRICS_SECURE: "false"
         run: |
           echo "Deploying infrastructure for guide: $GUIDE_NAME (nightly)..."
           echo "  MODEL_ID: $MODEL_ID"


### PR DESCRIPTION
## Summary
- Adds `WVA_METRICS_SECURE=false` to the nightly E2E deploy step
- On OpenShift user-workload-monitoring, Prometheus cannot authenticate to the WVA controller's `/metrics` endpoint using the controller-manager SA token (`Token does not match server's copy`)
- This prevents `wva_desired_replicas` from reaching the external metrics API, causing the ShareGPT scale-up test to fail
- Disabling auth on the `/metrics` endpoint is safe — it's only accessible within the cluster network

## Test plan
- [ ] Nightly E2E run passes the "should verify external metrics API is accessible" test
- [ ] `wva_desired_replicas` is available via external metrics API