### PR TITLE
✨ Add canonical repo template with org-wide best practices

### DIFF
--- a/templates/repo-template/.github/CODEOWNERS
+++ b/templates/repo-template/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# TODO: Replace with your team's GitHub usernames or team names
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+# * @llm-d/your-team

--- a/templates/repo-template/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/templates/repo-template/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Describe the bug and expected behavior
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version are you running? (e.g., v0.1.0, commit SHA, or "main")
+      placeholder: v0.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Deploy with config...
+        2. Send request to...
+        3. Observe error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide relevant environment details.
+      placeholder: |
+        - Kubernetes version:
+        - Cloud provider:
+        - GPU type:
+        - OS:
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code.
+      render: shell
+    validations:
+      required: false

--- a/templates/repo-template/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/repo-template/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/llm-d/llm-d/discussions
+    about: Ask questions and discuss ideas in the llm-d community
+  - name: Slack
+    url: https://cloud-native.slack.com/archives/llm-d
+    about: Chat with the community on Slack

--- a/templates/repo-template/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/templates/repo-template/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Suggest a new feature or improvement.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+
+        Thank you for suggesting an improvement! Please fill in the details below.
+
+        Before opening a new feature request, please check
+        [existing issues](https://github.com/llm-d/{{PROJECT_NAME}}/issues)
+        to see if a similar request already exists.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        What problem does this feature solve? Describe the use case or pain point.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Describe the solution you'd like. Be as specific as possible about
+        expected behavior and user experience.
+      placeholder: "Ideally, it would..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to Contribute
+      description: Would you be willing to help implement this feature?
+      options:
+        - "Yes, I can submit a PR"
+        - "Yes, with guidance"
+        - "No, but I can help test"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, links, or references.
+    validations:
+      required: false

--- a/templates/repo-template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/repo-template/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What does this PR do?
+
+<!-- Describe the changes and their purpose -->
+
+## Why is this change needed?
+
+<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->
+
+## How was this tested?
+
+<!-- Describe how you verified the changes work correctly -->
+- [ ] Unit tests added/updated
+- [ ] Integration/e2e tests added/updated
+- [ ] Manual testing performed
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
+- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
+- [ ] Tests pass locally (`make test`)
+- [ ] Linters pass (`make lint`)
+- [ ] Documentation updated (if applicable)
+
+## Related Issues
+
+<!-- Link to related issues: Fixes #123, Related to #456 -->

--- a/templates/repo-template/.github/actions/docker-build-and-push/action.yml
+++ b/templates/repo-template/.github/actions/docker-build-and-push/action.yml
@@ -1,0 +1,54 @@
+name: Docker Build and Push
+description: Build and push multi-arch container image to ghcr.io
+
+inputs:
+  image-name:
+    required: true
+    description: Image name (e.g., my-project)
+  tag:
+    required: true
+    description: Image tag (e.g., v0.1.0)
+  github-token:
+    required: true
+    description: GitHub token for ghcr.io login
+  registry:
+    required: false
+    description: Container registry
+    default: ghcr.io/llm-d
+  platforms:
+    required: false
+    description: Target platforms
+    default: linux/amd64,linux/arm64
+  prerelease:
+    required: false
+    description: If true, skip tagging as 'latest'
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      shell: bash
+
+    - name: Build and push image
+      run: |
+        if [[ "${{ inputs.prerelease }}" == "true" ]]; then
+          LATEST_TAG=""
+        else
+          LATEST_TAG="-t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+        fi
+        docker buildx build \
+          --platform ${{ inputs.platforms }} \
+          --push \
+          --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+          --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+          -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
+          ${LATEST_TAG} .
+      shell: bash

--- a/templates/repo-template/.github/actions/trivy-scan/action.yml
+++ b/templates/repo-template/.github/actions/trivy-scan/action.yml
@@ -1,0 +1,26 @@
+name: Trivy Security Scan
+description: Scan container image for HIGH and CRITICAL vulnerabilities
+
+inputs:
+  image:
+    required: true
+    description: Container image to scan (e.g., ghcr.io/llm-d/my-project:v0.1.0)
+  severity:
+    required: false
+    description: Severity levels to report
+    default: HIGH,CRITICAL
+  exit-code:
+    required: false
+    description: Exit code when vulnerabilities are found (0 = warn only, 1 = fail)
+    default: "0"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ${{ inputs.image }}
+        format: table
+        severity: ${{ inputs.severity }}
+        exit-code: ${{ inputs.exit-code }}

--- a/templates/repo-template/.github/dependabot.yml
+++ b/templates/repo-template/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Canonical Dependabot configuration for llm-d repos
+# Copy this file to .github/dependabot.yml in your repo
+#
+# Covers: Go modules, GitHub Actions, Docker base images
+# Remove sections that don't apply to your repo
+
+version: 2
+updates:
+
+  # Go module updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(go)"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    ignore:
+      # Ignore major and minor updates to Go toolchain
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major and minor version updates to k8s packages
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major updates for all packages
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Python dependencies (uncomment if repo uses pip/requirements.txt)
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels:
+  #     - "dependencies"
+  #   commit-message:
+  #     prefix: "deps(pip)"

--- a/templates/repo-template/.github/workflows/check-typos.yaml
+++ b/templates/repo-template/.github/workflows/check-typos.yaml
@@ -1,0 +1,8 @@
+name: Check Typos
+on:
+  pull_request:
+  push:
+
+jobs:
+  typos:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main

--- a/templates/repo-template/.github/workflows/ci-pr-checks.yaml
+++ b/templates/repo-template/.github/workflows/ci-pr-checks.yaml
@@ -1,0 +1,117 @@
+name: CI - PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # Detect if PR contains code changes (skip expensive checks for docs-only PRs)
+  check-code-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has_code_changes: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!OWNERS'
+
+  # Go: lint, build, and test
+  lint-and-test:
+    runs-on: ubuntu-latest
+    needs: check-code-changes
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.8.0
+          args: ""
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+  # Python: lint (only if Python files exist)
+  python-lint:
+    runs-on: ubuntu-latest
+    needs: check-code-changes
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Check for Python files
+        id: check-python
+        run: |
+          if find . -name "*.py" -not -path "./.git/*" | head -1 | grep -q .; then
+            echo "has_python=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_python=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.check-python.outputs.has_python == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        if: steps.check-python.outputs.has_python == 'true'
+        run: pip install ruff
+
+      - name: Run ruff check
+        if: steps.check-python.outputs.has_python == 'true'
+        run: ruff check .
+
+      - name: Run ruff format check
+        if: steps.check-python.outputs.has_python == 'true'
+        run: ruff format --check .
+
+  # Container: build (no push) to validate Dockerfile
+  container-build:
+    runs-on: ubuntu-latest
+    needs: check-code-changes
+    if: needs.check-code-changes.outputs.has_code_changes == 'true'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container (no push)
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --tag test-build:pr-${{ github.event.pull_request.number }} \
+            .

--- a/templates/repo-template/.github/workflows/ci-release.yaml
+++ b/templates/repo-template/.github/workflows/ci-release.yaml
@@ -1,0 +1,53 @@
+name: CI - Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set project name from repository
+        id: meta
+        run: |
+          repo="${GITHUB_REPOSITORY##*/}"
+          echo "project_name=$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: Build and push
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          image-name: ${{ steps.meta.outputs.project_name }}
+          tag: ${{ steps.tag.outputs.tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.tag.outputs.prerelease }}
+
+      - name: Trivy security scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/llm-d/${{ steps.meta.outputs.project_name }}:${{ steps.tag.outputs.tag }}

--- a/templates/repo-template/.github/workflows/ci-signed-commits.yaml
+++ b/templates/repo-template/.github/workflows/ci-signed-commits.yaml
@@ -1,0 +1,9 @@
+name: Check Signed Commits
+on: pull_request_target
+
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/templates/repo-template/.github/workflows/md-link-check.yml
+++ b/templates/repo-template/.github/workflows/md-link-check.yml
@@ -1,0 +1,11 @@
+name: Markdown Link Check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  links:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main

--- a/templates/repo-template/.github/workflows/non-main-gatekeeper.yml
+++ b/templates/repo-template/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,8 @@
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/templates/repo-template/.github/workflows/prow-github.yml
+++ b/templates/repo-template/.github/workflows/prow-github.yml
@@ -1,0 +1,12 @@
+name: Prow Commands
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main

--- a/templates/repo-template/.github/workflows/prow-pr-automerge.yml
+++ b/templates/repo-template/.github/workflows/prow-pr-automerge.yml
@@ -1,0 +1,8 @@
+name: Prow Auto-merge
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+
+jobs:
+  auto-merge:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main

--- a/templates/repo-template/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/templates/repo-template/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,0 +1,6 @@
+name: Prow Remove LGTM
+on: pull_request
+
+jobs:
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main

--- a/templates/repo-template/.github/workflows/stale.yaml
+++ b/templates/repo-template/.github/workflows/stale.yaml
@@ -1,0 +1,11 @@
+name: Mark Stale Issues
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/templates/repo-template/.github/workflows/unstale.yaml
+++ b/templates/repo-template/.github/workflows/unstale.yaml
@@ -1,0 +1,12 @@
+name: Unstale Issues
+on:
+  issues:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+    permissions:
+      issues: write

--- a/templates/repo-template/.golangci.yml
+++ b/templates/repo-template/.golangci.yml
@@ -1,0 +1,122 @@
+version: "2"
+run:
+  concurrency: 4
+  go: ""
+  modules-download-mode: readonly
+  issues-exit-code: 1
+  tests: true
+output:
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: false
+      colors: false
+linters:
+  default: none
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - ginkgolinter
+    - gocritic
+    - godot
+    - gosec
+    - govet
+    - grouper
+    - importas
+    - ineffassign
+    - lll
+    - loggercheck
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - staticcheck
+    # - tagliatelle
+    - testableexamples
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - varnamelen
+    - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    lll:
+      line-length: 130
+    nakedret:
+      max-func-lines: 1
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    staticcheck:
+      checks:
+        - all
+    varnamelen:
+      max-distance: 20
+      min-name-length: 2
+      check-type-param: true
+      ignore-type-assert-ok: true
+      ignore-map-index-ok: true
+      ignore-chan-recv-ok: true
+      ignore-decls:
+        - c echo.Context
+        - t *testing.T
+        - w http.ResponseWriter
+        - r *http.Request
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  uniq-by-line: false
+  fix: false
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/templates/repo-template/.hadolint.yaml
+++ b/templates/repo-template/.hadolint.yaml
@@ -1,0 +1,24 @@
+---
+failure-threshold: warning  # only fail on warnings and errors, not info
+
+ignored:
+  # already ignored in pre-commit
+  - DL3008  # pin versions for apt-get
+  - DL3009  # delete apt-get cache
+
+  # workflow/build patterns
+  - DL3003  # use WORKDIR instead of cd
+  - DL3059  # multiple consecutive RUN instructions
+  - DL4001  # using both wget and curl
+
+  # package manager preferences
+  - DL3015  # avoid additional packages (--no-install-recommends)
+  - DL3041  # specify version with dnf install
+  - DL3042  # avoid cache directory with pip
+  - DL3047  # wget without progress bar
+
+  # shellcheck rules embedded in hadolint
+  - SC1091  # not following sourced files
+  - SC2034  # variable appears unused
+  - SC2046  # quote to prevent word splitting
+  - SC2086  # double quote to prevent globbing

--- a/templates/repo-template/.pre-commit-config.yaml
+++ b/templates/repo-template/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+# Canonical pre-commit configuration for llm-d repos
+# Copy this file to the root of your repo
+#
+# Install: pip install pre-commit && pre-commit install
+# Run all: pre-commit run --all-files
+
+repos:
+  # General file hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # allows custom YAML tags used in k8s
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-case-conflict
+
+  # Shell script linting (requires shellcheck installed)
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        args: [-x, --severity=warning]
+        types: [shell]
+
+  # Dockerfile linting (requires hadolint installed)
+  - repo: local
+    hooks:
+      - id: hadolint-docker
+        name: hadolint
+        language: system
+        entry: hadolint
+        args: [--failure-threshold, error]
+        files: Dockerfile(\\..*)?$
+        types: [file]
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args:
+          - -d
+          - >-
+            {extends: default, rules: {line-length: {max: 250},
+            document-start: disable, truthy: {check-keys: false}}}

--- a/templates/repo-template/.prowlabels.yaml
+++ b/templates/repo-template/.prowlabels.yaml
@@ -1,0 +1,11 @@
+# Labels for labeling issues and pull requests using GitHub prow action.
+kind:
+  - 'bug'
+  - 'security'
+  - 'feature'
+  - 'docs'
+
+priority:
+  - 'p0'
+  - 'p1'
+  - 'p2'

--- a/templates/repo-template/.yamllint.yml
+++ b/templates/repo-template/.yamllint.yml
@@ -1,0 +1,8 @@
+# YAML lint configuration for Kubernetes-heavy repos
+extends: default
+rules:
+  line-length:
+    max: 250
+  document-start: disable
+  truthy:
+    check-keys: false

--- a/templates/repo-template/CODE_OF_CONDUCT.md
+++ b/templates/repo-template/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+## Code of Conduct and Covenant
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+For answers to common questions about this code of conduct, see <https://www.contributor-covenant.org/faq>

--- a/templates/repo-template/CONTRIBUTING.md
+++ b/templates/repo-template/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+## Contributing Guidelines
+
+Thank you for your interest in contributing to this project. Community involvement is highly valued and crucial for the project's growth and success. This project accepts contributions via GitHub pull requests. This document outlines the process to help get your contribution accepted.
+
+To ensure a clear direction and cohesive vision for the project, the project leads have the final decision on all contributions. However, these guidelines outline how you can contribute effectively.
+
+## How You Can Contribute
+
+There are several ways you can contribute:
+
+* **Reporting Issues:** Help us identify and fix bugs by reporting them clearly and concisely.
+* **Suggesting Features:** Share your ideas for new features or improvements.
+* **Improving Documentation:** Help make the project more accessible by enhancing the documentation.
+* **Submitting Code Contributions:** Code contributions that align with the project's vision are always welcome.
+
+## Code of Conduct
+
+This project adheres to the [Code of Conduct and Covenant](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Community and Communication
+
+* **Developer Slack:** [Join our developer Slack workspace](https://llm-d.ai/slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions.
+* **Weekly Meetings:** Project updates, ongoing work discussions, and Q&A will be covered in our weekly project meetings. Please join by [adding the shared calendar](https://red.ht/llm-d-public-calendar). You can also [join our Google Group](https://groups.google.com/g/llm-d-contributors) for access to shared content.
+* **Code:** Hosted in the [llm-d](https://github.com/llm-d) GitHub organization
+* **Issues:** Project-scoped bugs or issues should be reported in this repo or in [llm-d/llm-d](https://github.com/llm-d/llm-d)
+* **Mailing List:** [llm-d-contributors@googlegroups.com](mailto:llm-d-contributors@googlegroups.com)
+
+## Contributing Process
+
+We follow a **lazy consensus** approach: changes proposed by people with responsibility for a problem, without disagreement from others, within a bounded time window of review by their peers, should be accepted.
+
+### Types of Contributions
+
+#### 1. Features with Public APIs or New Components
+
+All features involving public APIs, behavior between core components, or new core subsystems must be accompanied by an **approved project proposal**.
+
+**Process:**
+
+1. Create a pull request adding a proposal document under `./docs/proposals/` with a descriptive name
+2. Include these sections: Summary, Motivation (Goals/Non-Goals), Proposal, Design Details, Alternatives
+3. Get review from impacted component maintainers
+4. Get approval from project maintainers
+
+#### 2. Fixes, Issues, and Bugs
+
+For changes that fix broken code or add small changes within a component:
+
+* All bugs and commits must have a clear description of the bug, how to reproduce, and how the change is made
+* Any other changes can be proposed in a pull request — a maintainer must approve the change
+* For moderate size changes, create an RFC issue in GitHub, then engage in Slack
+
+## Code Review Requirements
+
+* **All code changes** must be submitted as pull requests (no direct pushes)
+* **All changes** must be reviewed and approved by a maintainer other than the author
+* **All repositories** must gate merges on compilation and passing tests
+* **All experimental features** must be off by default and require explicit opt-in
+
+## Commit and Pull Request Style
+
+* **Pull requests** should describe the problem succinctly
+* **Rebase and squash** before merging
+* **Use minimal commits** and break large changes into distinct commits
+* **Commit messages** should have:
+  * Short, descriptive titles
+  * Description of why the change was needed
+  * Enough detail for someone reviewing git history to understand the scope
+* **DCO Sign-off**: All commits must include a valid DCO sign-off line (`Signed-off-by: Name <email@domain.com>`)
+  * Add automatically with `git commit -s`
+  * See [PR_SIGNOFF.md](PR_SIGNOFF.md) for configuration details
+  * Required for all contributions per [Developer Certificate of Origin](https://developercertificate.org/)
+
+## Code Organization and Ownership
+
+* **Components** are the primary unit of code organization
+* **Maintainers** own components and approve changes
+* **Contributors** can become maintainers through sufficient evidence of contribution
+* Code ownership is reflected in [OWNERS files](https://go.k8s.io/owners) consistent with Kubernetes project conventions
+
+## Testing Requirements
+
+We use three tiers of testing:
+
+1. **Unit tests**: Fast verification of code parts, testing different arguments
+2. **Integration tests**: Testing protocols between components and built artifacts
+3. **End-to-end (e2e) tests**: Whole system testing including benchmarking
+
+Strong e2e coverage is required for deployed systems to prevent performance regression. Appropriate test coverage is an important part of code review.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for our vulnerability disclosure process.
+
+## API Changes and Deprecation
+
+* **No breaking changes**: Once an API/protocol is in GA release, it cannot be removed or behavior changed
+* **Versioning**: All protocols and APIs should be versionable with clear compatibility requirements
+* **Documentation**: All APIs must have documented specs describing expected behavior

--- a/templates/repo-template/Dockerfile
+++ b/templates/repo-template/Dockerfile
@@ -1,0 +1,25 @@
+# Multi-stage build for {{PROJECT_NAME}}
+# Supports multi-arch: linux/amd64, linux/arm64
+
+# --- Build stage ---
+FROM golang:1.24 AS builder
+
+WORKDIR /workspace
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /workspace/app .
+
+# --- Runtime stage ---
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /
+COPY --from=builder /workspace/app .
+
+USER 65532:65532
+
+ENTRYPOINT ["/app"]

--- a/templates/repo-template/LICENSE
+++ b/templates/repo-template/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/templates/repo-template/Makefile
+++ b/templates/repo-template/Makefile
@@ -1,0 +1,107 @@
+# Project configuration
+# TODO: Replace {{PROJECT_NAME}} with your project name
+PROJECT_NAME ?= {{PROJECT_NAME}}
+REGISTRY ?= ghcr.io/llm-d
+IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Go configuration
+GOFLAGS ?=
+LDFLAGS ?= -s -w -X main.version=$(VERSION)
+
+# Tools
+GOLANGCI_LINT_VERSION ?= v2.8.0
+
+.DEFAULT_GOAL := help
+
+##@ General
+
+.PHONY: help
+help: ## Show this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: build
+build: ## Build the Go binary
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/$(PROJECT_NAME) .
+
+.PHONY: test
+test: ## Run tests with race detection
+	go test -race -count=1 ./...
+
+.PHONY: test-coverage
+test-coverage: ## Run tests with coverage report
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go tool cover -html=coverage.out -o coverage.html
+
+.PHONY: lint
+lint: lint-go lint-python ## Run all linters
+
+.PHONY: lint-go
+lint-go: ## Run Go linter (golangci-lint v2)
+	golangci-lint run
+
+.PHONY: lint-python
+lint-python: ## Run Python linter (ruff) — skipped if no Python files found
+	@if ls *.py **/*.py 2>/dev/null | head -1 > /dev/null 2>&1; then \
+		ruff check . && ruff format --check .; \
+	else \
+		echo "No Python files found, skipping Python lint"; \
+	fi
+
+.PHONY: fmt
+fmt: ## Format Go and Python code
+	gofmt -w .
+	@if ls *.py **/*.py 2>/dev/null | head -1 > /dev/null 2>&1; then \
+		ruff format .; \
+	fi
+
+.PHONY: generate
+generate: ## Run go generate
+	go generate ./...
+
+.PHONY: vet
+vet: ## Run go vet
+	go vet ./...
+
+.PHONY: tidy
+tidy: ## Run go mod tidy
+	go mod tidy
+
+.PHONY: pre-commit
+pre-commit: ## Run pre-commit hooks on all files
+	pre-commit run --all-files
+
+##@ Container
+
+.PHONY: image-build
+image-build: ## Build multi-arch container image (local only)
+	docker buildx build \
+		--platform $(PLATFORMS) \
+		--tag $(IMAGE):$(VERSION) \
+		--tag $(IMAGE):latest \
+		.
+
+.PHONY: image-push
+image-push: ## Build and push multi-arch container image
+	docker buildx build \
+		--platform $(PLATFORMS) \
+		--push \
+		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d/$(PROJECT_NAME)" \
+		--annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+		--tag $(IMAGE):$(VERSION) \
+		--tag $(IMAGE):latest \
+		.
+
+##@ CI Helpers
+
+.PHONY: ci-lint
+ci-lint: ## CI: install and run golangci-lint
+	@which golangci-lint > /dev/null 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	golangci-lint run
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	rm -rf bin/ coverage.out coverage.html

--- a/templates/repo-template/OWNERS
+++ b/templates/repo-template/OWNERS
@@ -1,0 +1,8 @@
+# TODO: Replace with your team's GitHub usernames
+# See https://go.k8s.io/owners for format documentation
+
+reviewers:
+  # - github-username
+
+approvers:
+  # - github-username

--- a/templates/repo-template/PR_SIGNOFF.md
+++ b/templates/repo-template/PR_SIGNOFF.md
@@ -1,0 +1,203 @@
+# Git Commit Signoff and Signing
+
+**NOTE**: "sign-off" is different from "signing" a commit.  The former
+indicates your assent to the repository's terms for contributors, the
+latter adds a cryptographic signature that is rarely displayed.  See
+[the git
+book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
+about signing. For commit signoff, do a web search on `git
+signoff`. GitHub has a concept of [a commit being
+"verified"](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+that extends the Git concept of signing.
+
+In order to get a pull request approved, you must first complete a DCO
+sign-off for each commit that the request is asking to add to the
+repository. This process is defined by the CNCF, and there are two
+cases: individual contributors and contributors that work for a
+corporate CNCF member. Both mean consent with the terms stated in [the
+`DCO` file at the root of this Git
+repository](https://github.com/llm-d/llm-d/blob/main/DCO). In
+the case of an individual, DCO sign-off is accomplished by doing a Git
+"sign-off" on the commit.
+
+We prefer that commits contributed to this repository be signed and
+GitHub verified, but this is not strictly necessary or enforced.
+
+## Commit Sign-off
+
+Your submitted PR must pass the automated checks in order to be merged. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For example, the following command will create a signed-off commit but _not_ sign it.
+
+```shell
+git commit -s
+```
+
+Alternatively, the following command will create a commit that is both signed-off and signed.
+
+```shell
+git commit -s -S
+```
+
+For other tools, consult their documentation.
+
+## Signing Commits
+
+Before signing any commits, you must have a GPG or SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
+
+To sign a particular commit, you must either include `-S` on the `git commit` command line (see the command exhibited above for an example) or have configured automatic signing (see ["Everyone Must Sign" in the Git Book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work#_everyone_must_sign) for a hint about that).
+
+Before starting, make sure that your user email is verified on Github. To check for this:
+
+1. Login to Github and navigate to your Github **Settings** page
+2. In the sidebar, open the **Emails** tab
+3. Emails associated with Github should be listed at the top of the page under the "Emails" label
+4. An unverified email would have an "Unverified" label under it in orange text
+5. To verify, click **Resend verification email** and follow its prompts
+6. Navigate back to your **Emails** page, if the "Unverified" label is no longer there, then you're good to go!
+
+<br />
+
+For Windows users, **Git Bash** is also highly recommended.
+
+<br />
+
+## Setting up the GPG Key
+
+1. Install GnuPG (the GPG command line tool).
+    - Binary releases for your specific OS can be found
+      [on the GnuPG download page](https://www.gnupg.org/download/) after scrolling down to the Binary Releases
+      section (i.e. Gpg4win on Windows, Mac GPG for MacOS, etc).
+    - After downloading the installer, follow the prompts to set up GnuPG.
+
+2. Open Git Bash (or your CLI of choice) and use the following command to generate your GPG key pair:
+
+   ```shell
+   gpg --full-generate-key
+   ```
+
+3. If prompted to specify the size, type, and duration of the key that you want, press `Enter` to select the default option.
+4. Once prompted, enter your user info and a passphrase:
+    - Make sure to list your email as the same one that's verified by Github
+5. Use the following command to list the long form of your generated GPG keys:
+
+   ```shell
+   gpg --list-secret-keys --keyid-format=long
+   ```
+
+    - Your GPG key ID should be the characters on the output line starting with `sec`, beginning directly after the `/` and ending before the listed date.
+    - For example, in the output below (from the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) setup page), the GPG key ID would be `3AA5C34371567BD2`
+
+        ```shell
+        $ gpg --list-secret-keys --keyid-format=long
+         /Users/hubot/.gnupg/secring.gpg
+         ------------------------------------
+         sec   4096R/3AA5C34371567BD2 2016-03-10 [expires: 2017-03-10]
+         uid                          Hubot <hubot@example.com>
+         ssb   4096R/4BB6D45482678BE3 2016-03-10
+        ```
+
+6. Copy your GPG key ID and run the command below, replacing `[your_GPG_key_ID]` with the key ID you just copied:
+
+    ```shell
+    gpg --armor --export [your_GPG_key_ID]
+    ```
+
+7. This should generate an output with your GPG key. Copy the characters starting from `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending at `--END PGP PUBLIC KEY BLOCK-----` (inclusive) to your clipboard.
+8. After copying or saving your GPG key, navigate to **Settings** in your Github
+9. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar
+10. Under GPG keys, select **New GPG key**
+    - Enter a suitable name for your key under "Title" and paste your GPG key that you copied/saved in **Step 7** under "Key".
+    - Once done, click **Add GPG key**
+11. Your new GPG key should now be displayed under GPG keys.
+
+<br />
+
+## Setting up the SSH Key
+
+1. Open Git Bash (or your CLI of choice) and use the following command to generate your new SSH key (make sure to replace `your_email` with your Github-verified email address):
+
+    ```shell
+    ssh-keygen -t ed25519 -C "your_email"
+    ```
+
+2. Press `Enter` to select the default option if prompted to set a save-file or passphrase for the key (you may choose to enter a passphrase if desired; this will prompt you to enter the passphrase every time you perform a DCO sign-off).
+   - The following output should generate a `randomart` image
+3. Use the following command to copy the **public** part of the new SSH key to your clipboard:
+
+    ```shell
+    clip < ~/.ssh/id_ed25519.pub
+    ```
+
+    Note: If you are in a WSL shell, use instead
+
+   ```shell
+   clip.exe < ~/.ssh/id_ed25519.pub
+   ```
+
+4. After copying or saving your SSH key, navigate to **Settings** in your Github.
+5. Navigate to the **SSH and GPG keys** page under the Access section in the sidebar.
+6. Under SSH keys, select **New SSH key**.
+    - Enter a suitable name for your key under "Title" (it'll pick up the email address if left empty)
+    - Open the dropdown menu under "Key type" and select **Signing Key**
+    - Paste your SSH public key that you copied/saved in **Step 3** under "Key"
+7. Your new SSH key should now be displayed under SSH keys, in the **Signing Key** section.
+8. **Optional**: If you want to use the same SSH or GPG key for authentication as well, repeat steps above, selecting **Authentication** as the "Key type".
+9. **Optional**: To test if your SSH key is connecting properly or not, run the following command in your CLI (more specific instructions can be found in the [Github documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)):
+
+    ```shell
+    ssh -T git@github.com
+    ```
+
+    - If given a warning saying something like `The authenticity of the host '[host IP]' can't be established` along
+      with a key fingerprint and a prompt to continue, verify if the provided key fingerprint matches any of those
+      listed [in GitHub's SSH key fingerprints documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+    - Once you've verified the match, type `yes`
+    - If the resulting message says something along the lines of `Hi [User]! You've successfully authenticated, but GitHub does not provide shell access.`, then it means your SSH key is up and ready.
+    - If you get an error saying something like `Error: Permission denied (publickey)` repeat the procedure in step 6 _with the same key_ only select **Authentication Key**. Then try the test command again.
+
+<br />
+
+## Creating Pull Requests Using the GitHub Website
+
+This is not recommended for individual contributors, because the commits that it produces are not "signed-off" (as defined by Git) and thus do not carry assent to the DCO; see [Repairing commits](#repairing-commits) below for a way to recover if you have inadvertently made such a PR. For corporate contributors the DCO assent is indicated differently.
+
+Whether it's editing files from llm-d.ai or directly from the llm-d Github, there are a couple steps to follow that streamlines the workflow of your PR:
+
+1. Changes made to any file are automatically committed to a new branch in your fork.
+    - After clicking **Commit changes...**, write your commit message summary line and any extended description that you want. Then click **Propose changes**, review your changes, and then create the PR.
+    - When making the PR, make sure to specify the type of PR at the beginning of the PR's title (i.e. :bug: if it addresses a bug-type issue)
+
+1. If the PR addresses a specific issue that has already been opened in GitHub, make sure to include the open issue number in **Related Issue(s)** (i.e. `Fixes #NNNN`); this will cause GitHub to automatically close the Issue once the PR is merged. If you have finished addressing an open issue without getting it automatically closed then explicitly close it.
+
+## Repairing commits
+
+If you have already created a PR that proposes to merge a branch that
+adds commits that are not signed-off then you can repair this (and
+lack of signing, if you choose) by adding the signoff to each using
+`git commit -s --amend` on each of them. If you also want those
+commits signed then you would use `git commit -s -S --amend` or
+configure automatic signing. Following is an outline of how to do it
+for a branch that adds **exactly one** commit. If your branch adds
+more than one commit then you can extrapolate using `git cherry-pick -s -S`
+(or `git rebase -i HEAD~NN` and setting commits to `edit`) to build up a
+revised series of commits one-by-one.
+
+The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation.
+
+1. Navigate to the **Code** page of the llm-d github.
+
+2. Click the **Fork** dropdown in the top right corner of the page.
+    - Under "Existing Forks" click your fork (should look something like "your_username/llm-d")
+3. Once in your fork, click the **Code** dropdown.
+    - Under the "Local" tab at the top of the dropdown, select the SSH tab
+    - Copy the SSH repo URL to your clipboard
+4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
+5. Clone the repository using `git clone` followed by pasting the URL you just copied.
+6. Change your directory to the llm-d repo using `cd llm-d`.
+7. `git checkout` to the branch in your fork where the changes were committed.
+    - The branch name should be written at the top of your submitted PR page and looks something like "patch-_X_" (where "X" should be the number of PRs made on your fork to date)
+8. Once in your branch, type `git commit -s --amend` to sign off your PR.
+    - The commit will also be signed if either you have set up automatic signing or both include the `-S` flag on that command and have set up your SSH or GPG key.
+    - You may extend that command with `-m` followed by a quoted commit message if you desire. Otherwise `git` will pop up an editor for you to use in making any desired adjustment to the commit message. After making any desired changes, save and exit the editor. FYI: in `vi` (which GitBash uses), when it is in Command mode (which is the normal mode, and contrasts with Insert mode) the keystrokes `:wq!` will attempt to save and then will exit no matter what.
+9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
+10. Navigate back to your PR github page.
+    - A green `dco-signoff: yes` label indicates that your PR is successfully signed

--- a/templates/repo-template/README.md
+++ b/templates/repo-template/README.md
@@ -1,0 +1,77 @@
+# {{PROJECT_NAME}}
+
+<!-- TODO: Replace {{PROJECT_NAME}} with your project name -->
+<!-- TODO: Update badges below with correct repo path -->
+
+[![CI](https://github.com/llm-d/{{PROJECT_NAME}}/actions/workflows/ci-pr-checks.yaml/badge.svg)](https://github.com/llm-d/{{PROJECT_NAME}}/actions/workflows/ci-pr-checks.yaml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+> **One-line description of what this project does.**
+
+## Overview
+
+<!-- TODO: Describe what this project does, why it exists, and how it fits into the llm-d ecosystem -->
+
+## Prerequisites
+
+- Go 1.24+
+- Docker (for container builds)
+- [pre-commit](https://pre-commit.com/) (for local development)
+
+## Quick Start
+
+```bash
+# Clone the repo
+git clone https://github.com/llm-d/{{PROJECT_NAME}}.git
+cd {{PROJECT_NAME}}
+
+# Install pre-commit hooks
+pre-commit install
+
+# Build
+make build
+
+# Run tests
+make test
+
+# Run linters
+make lint
+```
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines, coding standards, and how to submit changes.
+
+### Common Commands
+
+```bash
+make help           # Show all available targets
+make build          # Build the project
+make test           # Run tests with race detection
+make lint           # Run Go and Python linters
+make fmt            # Format Go and Python code
+make image-build    # Build multi-arch container image
+make pre-commit     # Run pre-commit hooks
+```
+
+## Architecture
+
+<!-- TODO: Add architecture overview, diagrams, or links to design docs -->
+
+## Configuration
+
+<!-- TODO: Document configuration options, environment variables, CLI flags -->
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+All commits must be signed off (DCO). See [PR_SIGNOFF.md](PR_SIGNOFF.md) for instructions.
+
+## Security
+
+To report a security vulnerability, please see [SECURITY.md](SECURITY.md).
+
+## License
+
+This project is licensed under the Apache License 2.0 - see [LICENSE](LICENSE) for details.

--- a/templates/repo-template/SECURITY.md
+++ b/templates/repo-template/SECURITY.md
@@ -1,0 +1,39 @@
+## Security Announcements
+
+Join the [llm-d-security-announce](https://groups.google.com/u/1/g/llm-d-security-announce) group for emails about security and major API announcements.
+
+## Report a Vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities to the llm-d Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
+You can email the private [llm-d-security-reporting@googlegroups.com](mailto:llm-d-security-reporting@googlegroups.com) list with the security details and the details expected for [all llm-d bug reports](.github/ISSUE_TEMPLATE/bug.yml).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in llm-d
+- You are unsure how a vulnerability affects llm-d
+- You think you discovered a vulnerability in another project that llm-d depends on
+  - For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning llm-d components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers of llm-d within 3 working days.
+
+Any vulnerability information shared with Security Response Committee stays within llm-d project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the llm-d Security Response Committee and the bug submitter.
+We prefer to fully disclose the bug as soon as possible once a user mitigation is available.
+It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination.
+The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks.
+For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days.
+The llm-d maintainers hold the final say when setting a disclosure date.

--- a/templates/repo-template/TEMPLATE_README.md
+++ b/templates/repo-template/TEMPLATE_README.md
@@ -1,0 +1,115 @@
+# llm-d Repo Template
+
+This directory contains the canonical repo template for all llm-d organization repositories. It codifies best practices gathered from across the org into a single, consistent starting point.
+
+## Using This Template
+
+### For New Repos
+
+1. Copy the entire `repo-template/` directory into your new repository:
+   ```bash
+   cp -r templates/repo-template/* templates/repo-template/.* /path/to/new-repo/
+   ```
+
+2. Find and replace all `{{PROJECT_NAME}}` placeholders with your project name:
+   ```bash
+   cd /path/to/new-repo
+   grep -r '{{PROJECT_NAME}}' --include='*.md' --include='*.yml' --include='*.yaml' --include='Makefile' --include='Dockerfile' --include='go.mod' -l | \
+     xargs sed -i '' 's/{{PROJECT_NAME}}/my-project/g'
+   ```
+
+3. Update these files with your project's specifics:
+   - `OWNERS` — Add your team's GitHub usernames
+   - `.github/CODEOWNERS` — Add your team
+   - `README.md` — Fill in the TODO sections
+   - `go.mod` — Run `go mod tidy` after adding dependencies
+   - `.github/ISSUE_TEMPLATE/feature_request.yml` — Update the repo link
+
+4. Remove this file (`TEMPLATE_README.md`) from your repo.
+
+5. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+### For Existing Repos
+
+Compare your repo against this template and adopt what's missing:
+
+```bash
+# See what files you're missing
+diff -rq templates/repo-template/ /path/to/your-repo/ --exclude='.git' --exclude='node_modules' --exclude='vendor'
+```
+
+Priority adoption order:
+1. **Governance** (if missing): `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `PR_SIGNOFF.md`
+2. **Linting** (if outdated): `.golangci.yml`, `.pre-commit-config.yaml`, `.hadolint.yaml`, `_typos.toml`
+3. **CI workflows** (if missing): Start with `ci-signed-commits.yaml`, `check-typos.yaml`, then `ci-pr-checks.yaml`
+4. **Prow integration**: `prow-github.yml`, `prow-pr-automerge.yml`, `prow-pr-remove-lgtm.yml`
+5. **Release pipeline**: `ci-release.yaml` + `.github/actions/`
+
+## What's Included
+
+### Governance
+| File | Purpose |
+|------|---------|
+| `LICENSE` | Apache 2.0 |
+| `CONTRIBUTING.md` | Development guidelines, lazy consensus model, testing tiers |
+| `CODE_OF_CONDUCT.md` | Contributor Covenant v1.4 |
+| `SECURITY.md` | Vulnerability disclosure process |
+| `PR_SIGNOFF.md` | DCO sign-off and GPG/SSH signing instructions |
+| `OWNERS` | Kubernetes-style reviewers/approvers |
+| `.github/CODEOWNERS` | GitHub code ownership |
+
+### Tooling & Linting
+| File | Purpose |
+|------|---------|
+| `.pre-commit-config.yaml` | Pre-commit hooks: shellcheck, hadolint, markdownlint, yamllint |
+| `.golangci.yml` | Go linter config (40+ linters, golangci-lint v2) |
+| `.hadolint.yaml` | Dockerfile linting rules |
+| `.yamllint.yml` | YAML lint (K8s-safe: 250 char lines, no doc-start requirement) |
+| `_typos.toml` | Spell checker false-positive exceptions |
+| `pyproject.toml` | Python: ruff linter + formatter config |
+| `.prowlabels.yaml` | Prow label definitions |
+
+### CI Workflows
+| File | Purpose |
+|------|---------|
+| `ci-pr-checks.yaml` | PR validation: Go lint/test/build, Python lint, container build |
+| `ci-release.yaml` | Tag-triggered: multi-arch build, push to ghcr.io, Trivy scan |
+| `ci-signed-commits.yaml` | DCO enforcement (calls llm-d-infra reusable workflow) |
+| `check-typos.yaml` | Spell checking (calls llm-d-infra reusable workflow) |
+| `md-link-check.yml` | Markdown link validation |
+| `stale.yaml` / `unstale.yaml` | Issue/PR staleness management |
+| `prow-github.yml` | Prow commands (`/lgtm`, `/approve`, `/hold`) |
+| `prow-pr-automerge.yml` | Auto-merge when Prow labels are set |
+| `prow-pr-remove-lgtm.yml` | Remove lgtm on new pushes |
+| `non-main-gatekeeper.yml` | Prevent PRs to non-main branches |
+
+### Build
+| File | Purpose |
+|------|---------|
+| `Makefile` | Standard targets: help, build, test, lint, fmt, image-build, image-push |
+| `Dockerfile` | Multi-stage, distroless, non-root, multi-arch ready |
+| `go.mod` | Go 1.24+ module template |
+| `.github/dependabot.yml` | Automated dependency updates (Go, Actions, Docker) |
+
+### GitHub
+| File | Purpose |
+|------|---------|
+| `.github/PULL_REQUEST_TEMPLATE.md` | Standardized PR checklist |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug report form |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature request form |
+| `.github/ISSUE_TEMPLATE/config.yml` | Disable blank issues, link to discussions |
+| `.github/actions/docker-build-and-push/` | Reusable Docker buildx composite action |
+| `.github/actions/trivy-scan/` | Reusable Trivy security scan composite action |
+
+## Sources
+
+Best practices were sourced from across the llm-d org:
+
+- **llm-d/llm-d** — Governance docs (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR_SIGNOFF)
+- **llm-d/kv-cache** — Go linter config (most comprehensive), Python/ruff config
+- **llm-d/llm-d-workload-variant-autoscaler** — CI patterns (PR checks, release pipeline)
+- **llm-d/llm-d-inference-sim** — Docker build + Trivy scan composite actions
+- **llm-d/llm-d-infra** — Reusable workflows, pre-commit config, dependabot config

--- a/templates/repo-template/_typos.toml
+++ b/templates/repo-template/_typos.toml
@@ -1,0 +1,14 @@
+# Typos configuration
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Azure Kubernetes Service abbreviation
+AKS = "AKS"
+aks = "aks"
+# Indian Standard Time / Istio abbreviation
+IST = "IST"
+# Abbreviation (e.g., 2nd -> ND)
+ND = "ND"
+
+# Add repo-specific false positives here:
+# word = "word"

--- a/templates/repo-template/go.mod
+++ b/templates/repo-template/go.mod
@@ -1,0 +1,3 @@
+module github.com/llm-d/{{PROJECT_NAME}}
+
+go 1.24.0

--- a/templates/repo-template/pyproject.toml
+++ b/templates/repo-template/pyproject.toml
@@ -1,0 +1,34 @@
+# Python tooling configuration
+# Only needed if this repo contains Python code
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "N",     # pep8-naming
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "S",     # flake8-bandit (security)
+    "A",     # flake8-builtins
+    "C4",    # flake8-comprehensions
+    "RET",   # flake8-return
+    "SIM",   # flake8-simplify
+]
+ignore = [
+    "S101",  # assert used (OK in tests)
+    "S603",  # subprocess call with shell=false (OK)
+    "S607",  # start process with partial path (OK)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary

- Adds a comprehensive repo template at `templates/repo-template/` with 37 files covering governance, CI, linting, build tooling, and GitHub config
- Sources best practices from across the llm-d org: governance from llm-d/llm-d, linting from kv-cache (40+ Go linters), CI patterns from WVA, Docker actions from inference-sim, reusable workflows from llm-d-infra
- Includes `TEMPLATE_README.md` with step-by-step instructions for bootstrapping new repos or updating existing ones

### What's included

| Category | Files | Source |
|----------|-------|--------|
| Governance | CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PR_SIGNOFF, OWNERS, CODEOWNERS | llm-d/llm-d |
| Go Linting | .golangci.yml (40+ linters, v2 format) | kv-cache |
| Python Linting | pyproject.toml (ruff config) | kv-cache |
| Pre-commit | .pre-commit-config.yaml (shellcheck, hadolint, markdownlint, yamllint) | llm-d-infra |
| CI - PR Checks | Go lint/test/build, Python lint, container build, docs-only skip | WVA (generalized) |
| CI - Release | Multi-arch Docker build, ghcr.io push, Trivy security scan | WVA (generalized) |
| CI - Callers | 9 thin workflow callers for llm-d-infra reusable workflows | All repos |
| Build | Makefile (14 targets), Dockerfile (multi-stage distroless), go.mod | WVA + llm-d |
| GitHub | PR template, issue templates (bug/feature), dependabot, config | llm-d/llm-d |
| Actions | docker-build-and-push, trivy-scan composite actions | inference-sim |

### Usage

**New repos:** Copy template, replace `{{PROJECT_NAME}}`, fill in OWNERS/CODEOWNERS, run `pre-commit install`

**Existing repos:** Compare against template, adopt missing files in priority order (governance → linting → CI → prow → release)

## Test plan

- [ ] All YAML files are valid syntax
- [ ] Workflow files reference correct reusable workflow paths in llm-d-infra
- [ ] `make help` produces self-documenting output from Makefile
- [ ] `TEMPLATE_README.md` explains usage clearly
- [ ] No repo-specific names leak through (all use `{{PROJECT_NAME}}` placeholders)
- [ ] Issue templates render correctly in GitHub UI