### PR TITLE
🌱 Mark legacy typo and link checker workflows

### DIFF
--- a/.github/workflows/reusable-md-link-check.yml
+++ b/.github/workflows/reusable-md-link-check.yml
@@ -1,7 +1,8 @@
-# Reusable Markdown Link Check workflow
-# Validates links in markdown files using lychee
+# LEGACY — Replaced by link-checker.md (gh-aw agentic workflow)
+# This reusable workflow is kept as a fallback. New repos should NOT use this.
+# See link-checker.md for the AI-powered replacement.
 #
-# Usage in consuming repo:
+# Previous usage in consuming repo:
 #   name: Markdown Link Check
 #   on:
 #     push:
@@ -13,7 +14,7 @@
 #     links:
 #       uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main
 
-name: Markdown Link Check (Reusable)
+name: "[LEGACY] Markdown Link Check (Reusable)"
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-typos.yml
+++ b/.github/workflows/reusable-typos.yml
@@ -1,7 +1,8 @@
-# Reusable Typos Check workflow
-# Spell-checks code and documentation
+# LEGACY — Replaced by typo-checker.md (gh-aw agentic workflow)
+# This reusable workflow is kept as a fallback. New repos should NOT use this.
+# See typo-checker.md for the AI-powered replacement.
 #
-# Usage in consuming repo:
+# Previous usage in consuming repo:
 #   name: Check Typos
 #   on:
 #     pull_request:
@@ -10,7 +11,7 @@
 #     typos:
 #       uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main
 
-name: Typos Check (Reusable)
+name: "[LEGACY] Typos Check (Reusable)"
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary
Marks `reusable-typos.yml` and `reusable-md-link-check.yml` as legacy. These are replaced by the gh-aw agentic equivalents (`typo-checker.md` and `link-checker.md`) added in PR #22.

Kept as fallback in case we need to revert.

## Test plan
- [x] Verify agentic replacements are in place (PR #22 merged)