### PR TITLE
🐛 Use waldorf runner label for CKS workflows

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -127,7 +127,7 @@ on:
 
 jobs:
   nightly-e2e:
-    runs-on: [self-hosted, linux, cks]
+    runs-on: [self-hosted, linux, waldorf]
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}
       GUIDE_PATH: ${{ inputs.guide_path || format('guides/{0}', inputs.guide_name) }}


### PR DESCRIPTION
## Summary
- Change `runs-on` from `[self-hosted, linux, cks]` to `[self-hosted, linux, waldorf]`
- More CKS clusters will be added — `waldorf` targets this specific cluster

## Test plan
- [ ] Verify reusable workflow targets correct runner