### PR TITLE
🐛 Fix CKS WVA deploy: use 'kubernetes' environment instead of 'default'

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -459,7 +459,7 @@ jobs:
       - name: Deploy guide via WVA install.sh
         if: inputs.deploy_wva
         env:
-          ENVIRONMENT: default
+          ENVIRONMENT: kubernetes
           INSTALL_GATEWAY_CTRLPLANE: "false"
           BENCHMARK_MODE: "false"
           E2E_TESTS_ENABLED: "true"


### PR DESCRIPTION
## Summary

- Fix `ENVIRONMENT: default` → `ENVIRONMENT: kubernetes` in the CKS reusable workflow's WVA install step

## Problem

The WVA `deploy/install.sh` only supports `kubernetes`, `openshift`, and `kind-emulator` environments. The CKS reusable workflow was passing `ENVIRONMENT=default`, causing the WVA install step to fail with:

```
[ERROR] Environment script not found: .../deploy/default/install.sh
```

**Failed run**: https://github.com/llm-d/llm-d/actions/runs/22117064760

## Fix

One-line change: `ENVIRONMENT: default` → `ENVIRONMENT: kubernetes` (line 462 of `reusable-nightly-e2e-cks-helmfile.yaml`)

The `deploy/kubernetes/install.sh` already exists in the WVA repo and provides the correct Kubernetes-specific config (Prometheus stack, TLS certs, namespace handling).

## Related

- Issue: https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/753