### PR TITLE
⚠️ Add allow_gpu_preemption to CKS reusable workflow

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -61,6 +61,11 @@ on:
         required: false
         type: number
         default: 4
+      allow_gpu_preemption:
+        description: 'When true, proceed with deployment even if GPUs are unavailable (relies on Kubernetes preemption of lower-priority pods)'
+        required: false
+        type: boolean
+        default: false
 
       # --- Model & accelerator ---
       model_id:
@@ -294,10 +299,16 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-            echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
-            exit 1
+            if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. Proceeding anyway (preemption enabled)." >> $GITHUB_STEP_SUMMARY
+              echo "::warning::Insufficient GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but allow_gpu_preemption=true — relying on Kubernetes preemption"
+            else
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
+              exit 1
+            fi
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds `allow_gpu_preemption` boolean input (default: false) to the CKS reusable workflow
- When true, the GPU availability check warns instead of hard-failing when insufficient GPUs are available
- This allows deployment to proceed, relying on Kubernetes pod preemption to evict lower-priority pods

## Context
The CKS cluster runs `hpc-verification` (NHC) pods every hour at priority **-1**, consuming all 64 GPUs for ~59 minutes. Default pods have priority 0, so Kubernetes *should* preempt hpc-verification — but the workflow's GPU check hard-fails before any pods are created, so preemption never gets a chance.

## Test plan
- [ ] CKS callers in llm-d/llm-d set `allow_gpu_preemption: true` (companion PR)
- [ ] Verify workflow proceeds when GPUs are consumed by hpc-verification
- [ ] Verify nightly pods preempt hpc-verification pods (priority -1 < 0)