### PR TITLE
🐛 Only allow GPU preemption when blocking pods have negative priority

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -300,9 +300,22 @@ jobs:
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
             if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. Proceeding anyway (preemption enabled)." >> $GITHUB_STEP_SUMMARY
-              echo "::warning::Insufficient GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but allow_gpu_preemption=true — relying on Kubernetes preemption"
+              # Check if GPU-consuming pods have negative priority (safe to preempt)
+              NEG_PRIORITY_GPU_PODS=$(kubectl get pods --all-namespaces -o json | \
+                jq '[.items[] | select(
+                  (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber) > 0
+                  and (.spec.priority // 0) < 0
+                )] | length')
+              if [ "$NEG_PRIORITY_GPU_PODS" -gt 0 ]; then
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. Found $NEG_PRIORITY_GPU_PODS GPU pod(s) with negative priority — proceeding (Kubernetes will preempt them)." >> $GITHUB_STEP_SUMMARY
+                echo "::warning::Insufficient GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but $NEG_PRIORITY_GPU_PODS pod(s) with negative priority can be preempted"
+              else
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. No negative-priority GPU pods found to preempt." >> $GITHUB_STEP_SUMMARY
+                echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS. No preemptable (negative priority) pods found."
+                exit 1
+              fi
             else
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Refines the `allow_gpu_preemption` logic from PR #30
- When GPUs are insufficient and preemption is enabled, checks if the GPU-consuming pods actually have negative priority (like `hpc-verification` at priority -1)
- Only proceeds if negative-priority GPU pods exist (safe to preempt)
- Fails as normal if all GPU-consuming pods have priority >= 0

## Context
Kubernetes preemption only evicts pods with **lower** priority. Our nightly pods at default priority 0 can preempt `hpc-verification` (priority -1), but should NOT blindly proceed when blocked by legitimate workloads at priority >= 0.

## Test plan
- [ ] Trigger CKS nightly while hpc-verification is running → should proceed (negative priority pods found)
- [ ] If GPUs are blocked by normal pods (priority >= 0) → should fail with error