### PR TITLE
✨ Add GPU wait/retry to nightly E2E reusable workflows

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -61,6 +61,11 @@ on:
         required: false
         type: number
         default: 4
+      gpu_wait_timeout:
+        description: 'Minutes to wait for GPUs to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
       allow_gpu_preemption:
         description: 'When true, proceed with deployment even if GPUs are unavailable (relies on Kubernetes preemption of lower-priority pods)'
         required: false
@@ -258,16 +263,19 @@ jobs:
         env:
           REQUIRED_GPUS: ${{ inputs.required_gpus }}
           RECOMMENDED_GPUS: ${{ inputs.recommended_gpus }}
+          GPU_WAIT_TIMEOUT: ${{ inputs.gpu_wait_timeout }}
         run: |
           echo "Checking GPU availability for nightly e2e ($GUIDE_NAME)..."
 
-          TOTAL_GPUS=$(kubectl get nodes -o json | \
-            jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+          check_gpus() {
+            TOTAL_GPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          }
 
-          ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-            jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
-
-          AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          check_gpus
 
           TOTAL_CPU=$(kubectl get nodes -o json | \
             jq '[.items[].status.allocatable.cpu // "0" | if endswith("m") then (gsub("m$";"") | tonumber / 1000) else tonumber end] | add | floor')
@@ -299,28 +307,54 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
-            if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
-              # Check if GPU-consuming pods have negative priority (safe to preempt)
-              NEG_PRIORITY_GPU_PODS=$(kubectl get pods --all-namespaces -o json | \
-                jq '[.items[] | select(
-                  (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber) > 0
-                  and (.spec.priority // 0) < 0
-                )] | length')
-              if [ "$NEG_PRIORITY_GPU_PODS" -gt 0 ]; then
-                echo "" >> $GITHUB_STEP_SUMMARY
-                echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. Found $NEG_PRIORITY_GPU_PODS GPU pod(s) with negative priority — proceeding (Kubernetes will preempt them)." >> $GITHUB_STEP_SUMMARY
-                echo "::warning::Insufficient GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but $NEG_PRIORITY_GPU_PODS pod(s) with negative priority can be preempted"
+            # Try waiting for GPUs first
+            if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for GPUs... need $REQUIRED_GPUS, have $AVAILABLE_GPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_gpus
+                if [ "$AVAILABLE_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] GPUs now available: $AVAILABLE_GPUS free"
+                  echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            # If still insufficient after waiting, try preemption or fail
+            if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+              if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
+                NEG_PRIORITY_GPU_PODS=$(kubectl get pods --all-namespaces -o json | \
+                  jq '[.items[] | select(
+                    (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber) > 0
+                    and (.spec.priority // 0) < 0
+                  )] | length')
+                if [ "$NEG_PRIORITY_GPU_PODS" -gt 0 ]; then
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. Found $NEG_PRIORITY_GPU_PODS GPU pod(s) with negative priority — proceeding (Kubernetes will preempt them)." >> $GITHUB_STEP_SUMMARY
+                  echo "::warning::Insufficient GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but $NEG_PRIORITY_GPU_PODS pod(s) with negative priority can be preempted"
+                else
+                  WAIT_MSG=""
+                  [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. No negative-priority GPU pods found to preempt." >> $GITHUB_STEP_SUMMARY
+                  echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS. No preemptable (negative priority) pods found.${WAIT_MSG}"
+                  exit 1
+                fi
               else
+                WAIT_MSG=""
+                [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
                 echo "" >> $GITHUB_STEP_SUMMARY
-                echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available. No negative-priority GPU pods found to preempt." >> $GITHUB_STEP_SUMMARY
-                echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS. No preemptable (negative priority) pods found."
+                echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+                echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
                 exit 1
               fi
             else
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
-              exit 1
+              echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
             fi
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -78,6 +78,11 @@ on:
         required: false
         type: number
         default: 4
+      gpu_wait_timeout:
+        description: 'Minutes to wait for GPUs to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
 
       # --- Model & accelerator ---
       model_id:
@@ -202,16 +207,19 @@ jobs:
         env:
           REQUIRED_GPUS: ${{ inputs.required_gpus }}
           RECOMMENDED_GPUS: ${{ inputs.recommended_gpus }}
+          GPU_WAIT_TIMEOUT: ${{ inputs.gpu_wait_timeout }}
         run: |
           echo "Checking GPU availability for nightly e2e ($GUIDE_NAME)..."
 
-          TOTAL_GPUS=$(kubectl get nodes -o json | \
-            jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+          check_gpus() {
+            TOTAL_GPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          }
 
-          ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-            jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
-
-          AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          check_gpus
 
           NODE_COUNT=$(kubectl get nodes --no-headers | wc -l | tr -d ' ')
           GPU_NODE_COUNT=$(kubectl get nodes -o json | \
@@ -236,10 +244,32 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+            if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for GPUs... need $REQUIRED_GPUS, have $AVAILABLE_GPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_gpus
+                if [ "$AVAILABLE_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] GPUs now available: $AVAILABLE_GPUS free"
+                  echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+              WAIT_MSG=""
+              [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
+              exit 1
+            fi
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-            echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
-            exit 1
+            echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -61,6 +61,11 @@ on:
         required: false
         type: number
         default: 4
+      gpu_wait_timeout:
+        description: 'Minutes to wait for GPUs to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
 
       # --- Model & accelerator ---
       model_id:
@@ -264,16 +269,19 @@ jobs:
         env:
           REQUIRED_GPUS: ${{ inputs.required_gpus }}
           RECOMMENDED_GPUS: ${{ inputs.recommended_gpus }}
+          GPU_WAIT_TIMEOUT: ${{ inputs.gpu_wait_timeout }}
         run: |
           echo "Checking GPU availability for nightly e2e ($GUIDE_NAME)..."
 
-          TOTAL_GPUS=$(kubectl get nodes -o json | \
-            jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+          check_gpus() {
+            TOTAL_GPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          }
 
-          ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-            jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
-
-          AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          check_gpus
 
           TOTAL_CPU=$(kubectl get nodes -o json | \
             jq '[.items[].status.allocatable.cpu // "0" | if endswith("m") then (gsub("m$";"") | tonumber / 1000) else tonumber end] | add | floor')
@@ -305,10 +313,33 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+            # Wait for GPUs if timeout is configured
+            if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for GPUs... need $REQUIRED_GPUS, have $AVAILABLE_GPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_gpus
+                if [ "$AVAILABLE_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] GPUs now available: $AVAILABLE_GPUS free"
+                  echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+              WAIT_MSG=""
+              [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
+              exit 1
+            fi
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-            echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
-            exit 1
+            echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -60,6 +60,11 @@ on:
         required: false
         type: number
         default: 4
+      gpu_wait_timeout:
+        description: 'Minutes to wait for GPUs to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
 
       # --- WVA-specific (ignored for non-WVA guides) ---
       wva_image_tag:
@@ -189,18 +194,19 @@ jobs:
         env:
           REQUIRED_GPUS: ${{ inputs.required_gpus }}
           RECOMMENDED_GPUS: ${{ inputs.recommended_gpus }}
+          GPU_WAIT_TIMEOUT: ${{ inputs.gpu_wait_timeout }}
         run: |
           echo "Checking GPU availability for nightly e2e ($GUIDE_NAME)..."
 
-          # Total allocatable GPUs across all nodes
-          TOTAL_GPUS=$(kubectl get nodes -o json | \
-            jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+          check_gpus() {
+            TOTAL_GPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          }
 
-          # Currently requested GPUs by all pods
-          ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-            jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
-
-          AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          check_gpus
 
           TOTAL_CPU=$(kubectl get nodes -o json | \
             jq '[.items[].status.allocatable.cpu // "0" | if endswith("m") then (gsub("m$";"") | tonumber / 1000) else tonumber end] | add | floor')
@@ -232,10 +238,32 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+            if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for GPUs... need $REQUIRED_GPUS, have $AVAILABLE_GPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_gpus
+                if [ "$AVAILABLE_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] GPUs now available: $AVAILABLE_GPUS free"
+                  echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+              WAIT_MSG=""
+              [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
+              exit 1
+            fi
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Insufficient GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-            echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available"
-            exit 1
+            echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds `gpu_wait_timeout` input to all 4 reusable nightly E2E workflows (OCP, OCP-helmfile, GKE, CKS)
- When set > 0, the GPU check step polls every 2 minutes instead of failing immediately
- Prevents spurious failures when GPUs are temporarily consumed by other nightly runs (e.g., sequential IS/PPC batches)
- Default is 0 (no wait) — fully backward compatible, no behavior change unless callers opt in
- CKS: wait happens before preemption check (try wait → then preempt → then fail)

## How it works
```yaml
# Caller example — wait up to 30 minutes for GPUs
uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
with:
  gpu_wait_timeout: 30  # minutes
```

The step logs countdown messages every 2 minutes:
```
[03:02:15] Waiting for GPUs... need 1, have -4 (28m remaining)
[03:04:15] Waiting for GPUs... need 1, have -4 (26m remaining)
[03:06:15] GPUs now available: 2 free
```

## Test plan
- [ ] Verify YAML syntax is valid (no workflow parse errors)
- [ ] Test with `gpu_wait_timeout: 0` (default) — should behave identically to before
- [ ] Test with `gpu_wait_timeout: 30` when GPUs are temporarily unavailable