### PR TITLE
🐛 Fix WVA deploy path in helmfile reusable workflows + add CODEOWNERS

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -542,6 +542,13 @@ jobs:
           echo "  WVA_NS: $WVA_NS"
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
           cd _caller
+          # WVA install.sh expects llm-d/ as a subdirectory (LLM_D_PROJECT=llm-d)
+          # but the helmfile workflow checks out llm-d/llm-d at the workspace root.
+          # Symlink so install.sh can find guides/ and charts/ where it expects them.
+          if [ ! -d "llm-d" ] && [ -d "$GITHUB_WORKSPACE/guides" ]; then
+            ln -s "$GITHUB_WORKSPACE" llm-d
+            echo "  Symlinked _caller/llm-d → $GITHUB_WORKSPACE"
+          fi
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME"
           cd "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -539,6 +539,13 @@ jobs:
           echo "  WVA_NS: $WVA_NS"
           echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
           cd _caller
+          # WVA install.sh expects llm-d/ as a subdirectory (LLM_D_PROJECT=llm-d)
+          # but the helmfile workflow checks out llm-d/llm-d at the workspace root.
+          # Symlink so install.sh can find guides/ and charts/ where it expects them.
+          if [ ! -d "llm-d" ] && [ -d "$GITHUB_WORKSPACE/guides" ]; then
+            ln -s "$GITHUB_WORKSPACE" llm-d
+            echo "  Symlinked _caller/llm-d → $GITHUB_WORKSPACE"
+          fi
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
           cd "$GITHUB_WORKSPACE"
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for llm-d-infra
+* @clubanderson @Gregory-Pereira


### PR DESCRIPTION
## Summary
- Fix WVA deploy path: `install.sh` expects `llm-d/` as a subdirectory of the WVA checkout (`_caller/`), but the helmfile workflows check out `llm-d/llm-d` at the workspace root. Adds a symlink `_caller/llm-d → $GITHUB_WORKSPACE` so `install.sh` can find `guides/` and `charts/` where it expects them.
- Applies to both OCP and CKS helmfile reusable workflows (GKE doesn't have a WVA step yet)
- Adds CODEOWNERS file (`@clubanderson @Gregory-Pereira`)

## Root cause
The `nightly-e2e-wva-ocp.yaml` caller in `llm-d/llm-d` calls the helmfile reusable workflow with `deploy_wva: true` and `caller_repo: llm-d/llm-d-workload-variant-autoscaler`. The workflow checks out the WVA repo to `_caller/` and `llm-d/llm-d` to `$GITHUB_WORKSPACE`. But `install.sh` runs `cd $EXAMPLE_DIR` which resolves to `_caller/llm-d/guides/workload-autoscaling` — that path doesn't exist because `llm-d/` is at the workspace root, not inside `_caller/`.

## Test plan
- [ ] Trigger `nightly-e2e-wva-ocp.yaml` from `llm-d/llm-d` after merge — should pass the deploy step