### PR TITLE
🐛 Fix yq image_override creating ghost containers keys

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -494,9 +494,10 @@ jobs:
           else
             for file in $VALUES_FILES; do
               echo "Updating vLLM image in ${file}..."
-              yq e '(.decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              # Guard each yq call: only modify if the key exists, otherwise yq creates ghost empty arrays
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
             done
           fi
         env:

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -336,9 +336,10 @@ jobs:
           else
             for file in $VALUES_FILES; do
               echo "Updating vLLM image in ${file}..."
-              yq e '(.decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              # Guard each yq call: only modify if the key exists, otherwise yq creates ghost empty arrays
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
             done
           fi
         env:

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -480,9 +480,10 @@ jobs:
           else
             for file in $VALUES_FILES; do
               echo "Updating vLLM image in ${file}..."
-              yq e '(.decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              # Guard each yq call: only modify if the key exists, otherwise yq creates ghost empty arrays
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
             done
           fi
         env:

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -362,9 +362,10 @@ jobs:
           else
             for file in $VALUES_FILES; do
               echo "Updating vLLM image in ${file}..."
-              yq e '(.decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
-              yq e '(.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              # Guard each yq call: only modify if the key exists, otherwise yq creates ghost empty arrays
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
             done
           fi
         env:


### PR DESCRIPTION
## Summary
- Fix `image_override` step in all 4 reusable E2E workflows creating ghost empty arrays in values files
- yq `(.containers[].image | select(...)) = "val"` on a file without root-level `containers` adds `containers: []`, which breaks `llm-d-modelservice` chart schema validation (`additionalProperties: false` rejects the ghost key)
- Same issue with `prefill.containers` when `prefill.create: false` and no `prefill.containers` exists

## Root Cause
The WVA nightly was failing with:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
llm-d-modelservice:
- at '': additional properties 'containers' not allowed
```

The `image_override` step runs three `yq` calls per values file:
1. `.decode.containers[].image` — works fine (key exists)
2. `.prefill.containers[].image` — creates `prefill.containers: []` when key doesn't exist
3. `.containers[].image` — creates root `containers: []` when key doesn't exist

## Fix
Guard each yq call with `select(.key != null)` so it becomes a no-op when the path doesn't exist:
```bash
yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("..."))) = strenv(IMAGE_OVERRIDE)' -i "$file"
```

## Test plan
- [x] Verified locally: yq with guard does NOT create ghost keys
- [x] Verified locally: yq with guard DOES correctly update existing images
- [ ] Trigger WVA nightly after merge to confirm fix