### PR TITLE
🐛 Fix HTTPRoute overwrite when deploy_wva is true

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -569,7 +569,7 @@ jobs:
           ${{ inputs.custom_deploy_script }}
 
       - name: Deploy HTTPRoute
-        if: inputs.httproute_file != '' && inputs.custom_deploy_script == ''
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == '' && !inputs.deploy_wva
         run: |
           HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
           if [ -f "$HTTPROUTE" ]; then


### PR DESCRIPTION
## Summary
- Skip the "Deploy HTTPRoute" step in `reusable-nightly-e2e-openshift-helmfile.yaml` when `deploy_wva` is true
- The WVA `install.sh` already deploys a correctly-templated HTTPRoute using `RELEASE_NAME_POSTFIX` to match gateway/pool names
- The reusable workflow's step was overwriting this with the raw `httproute.yaml` which has hardcoded default names (`workload-autoscaler` instead of `workload-autoscaling`), causing a name mismatch
- This resulted in the Istio gateway showing `attachedRoutes: 0` and returning HTTP 404 for all requests

## Root Cause
The `httproute.yaml` in the `workload-autoscaling` guide uses default resource names (e.g. `infra-workload-autoscaler-inference-gateway`), but the nightly workflow sets `RELEASE_NAME_POSTFIX=workload-autoscaling` (via `guide_name`), creating resources named `infra-workload-autoscaling-inference-gateway`. The WVA `install.sh` correctly templates the HTTPRoute, but the reusable workflow's "Deploy HTTPRoute" step then overwrites it with the un-templated file.

## Test plan
- [x] Verified fix live on pokprod cluster — gateway returned 200 after patching HTTPRoute names
- [ ] Re-run WVA nightly E2E after merging this fix