### PR TITLE
🐛 Fix node-exporter disable flag in CKS WVA nightly

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -554,7 +554,7 @@ jobs:
           # prometheus node-exporter DaemonSet from scheduling.  Disable it
           # so the helm install doesn't time out waiting for unschedulable pods.
           if [ -f deploy/kubernetes/install.sh ]; then
-            sed -i 's|helm upgrade --install kube-prometheus-stack|helm upgrade --install kube-prometheus-stack --set prometheus-node-exporter.enabled=false|' deploy/kubernetes/install.sh
+            sed -i 's|helm upgrade --install kube-prometheus-stack|helm upgrade --install kube-prometheus-stack --set nodeExporter.enabled=false|' deploy/kubernetes/install.sh
             echo "  Patched kubernetes/install.sh: disabled prometheus-node-exporter"
           fi
           ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME"


### PR DESCRIPTION
## Summary
- Fix the helm value key from `prometheus-node-exporter.enabled` to `nodeExporter.enabled`
- The kube-prometheus-stack chart uses `nodeExporter.enabled` as the condition in Chart.yaml to control the subchart deployment

## Context
PR #38 added the sed patch but used the wrong key name. The patch ran successfully (confirmed in logs) but had no effect because `prometheus-node-exporter.enabled` is not the correct condition key.