### PR TITLE
✨ Cordon unhealthy GPU nodes before nightly E2E tests

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -258,6 +258,26 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
 
+      - name: Cordon unhealthy GPU nodes
+        run: |
+          echo "Checking for unhealthy GPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r '
+            .items[] | select(
+              ((.status.allocatable["nvidia.com/gpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy GPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All GPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
+
       - name: Check GPU availability
         id: gpu-check
         env:
@@ -914,3 +934,14 @@ jobs:
           fi
 
           echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -207,6 +207,26 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
 
+      - name: Cordon unhealthy GPU nodes
+        run: |
+          echo "Checking for unhealthy GPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r '
+            .items[] | select(
+              ((.status.allocatable["nvidia.com/gpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy GPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All GPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
+
       - name: Check GPU availability
         id: gpu-check
         env:
@@ -617,3 +637,14 @@ jobs:
           kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || true
 
           echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -269,6 +269,26 @@ jobs:
           kubectl get nodes
           oc whoami || true
 
+      - name: Cordon unhealthy GPU nodes
+        run: |
+          echo "Checking for unhealthy GPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r '
+            .items[] | select(
+              ((.status.allocatable["nvidia.com/gpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy GPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All GPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
+
       - name: Check GPU availability
         id: gpu-check
         env:
@@ -945,3 +965,14 @@ jobs:
           fi
 
           echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi


### PR DESCRIPTION
## Summary
- Adds a **cordon step** before GPU availability check in all 3 reusable nightly workflows (OCP, CKS, GKE)
- Adds an **uncordon step** after cleanup that only uncordons nodes that THIS run cordoned
- Prevents nightly pods from being scheduled on flaky/unhealthy GPU nodes

## Problem
Nightly IS OCP failed because a pod was scheduled on `pokprod-b93r44s3` (Ready=Unknown, all conditions Unknown, gpu-feature-discovery CrashLoopBackOff). The pod couldn't start, causing the "Wait for pods to be ready" step to timeout.

## How it works
1. **Before GPU check**: queries all GPU nodes, finds any with `Ready != True`, cordons them
2. **Tracks cordoned nodes**: saves list in `NIGHTLY_CORDONED_NODES` env var
3. **After cleanup**: uncordons only the nodes that this run cordoned (preserves admin-initiated cordons)

## Test plan
- [ ] Trigger nightly on OCP with known unhealthy nodes — verify they're cordoned and pods don't land there
- [ ] Verify uncordon runs during cleanup (check logs)
- [ ] Verify admin-cordoned nodes are NOT uncordoned