### PR TITLE
🐛 Wait for rollout after priority patching to avoid pod wait race

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -657,6 +657,25 @@ jobs:
           done
           echo "Priority patching complete"
 
+          # Wait for rolling updates triggered by the priority patch to stabilize.
+          # Without this, kubectl wait sees pods from both old and new ReplicaSets,
+          # causing "NotFound" errors as old pods are deleted during rollout.
+          echo "Waiting for rollouts to stabilize after priority patching..."
+          for kind in deployment statefulset; do
+            for name in $(kubectl get "$kind" -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "  Waiting for $kind/$name rollout..."
+              kubectl rollout status "$kind/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+                echo "    Rollout status check timed out for $kind/$name (will retry in pod wait)"
+            done
+          done
+          # Also wait for LeaderWorkerSet rollouts, since they were patched above.
+          for name in $(kubectl get leaderworkersets -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "  Waiting for leaderworkerset/$name rollout..."
+            kubectl rollout status "leaderworkerset/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+              echo "    Rollout status check failed for leaderworkerset/$name (kubectl may not support rollout for this resource; will rely on pod wait)"
+          done
+          echo "Rollouts stabilized"
+
       - name: Show deployment status
         run: |
           echo "=== Deployments ==="

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -486,6 +486,25 @@ jobs:
           done
           echo "Priority patching complete"
 
+          # Wait for rolling updates triggered by the priority patch to stabilize.
+          # Without this, kubectl wait sees pods from both old and new ReplicaSets,
+          # causing "NotFound" errors as old pods are deleted during rollout.
+          echo "Waiting for rollouts to stabilize after priority patching..."
+          for kind in deployment statefulset; do
+            for name in $(kubectl get "$kind" -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "  Waiting for $kind/$name rollout..."
+              kubectl rollout status "$kind/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+                echo "    Rollout status check timed out for $kind/$name (will retry in pod wait)"
+            done
+          done
+          # Also wait for LeaderWorkerSet rollouts, since they were patched above.
+          for name in $(kubectl get leaderworkersets -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "  Waiting for leaderworkerset/$name rollout..."
+            kubectl rollout status "leaderworkerset/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+              echo "    Rollout status check failed for leaderworkerset/$name (kubectl may not support rollout for this resource; will rely on pod wait)"
+          done
+          echo "Rollouts stabilized"
+
       - name: Show deployment status
         run: |
           echo "=== Deployments ==="

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -674,6 +674,25 @@ jobs:
           done
           echo "Priority patching complete"
 
+          # Wait for rolling updates triggered by the priority patch to stabilize.
+          # Without this, kubectl wait sees pods from both old and new ReplicaSets,
+          # causing "NotFound" errors as old pods are deleted during rollout.
+          echo "Waiting for rollouts to stabilize after priority patching..."
+          for kind in deployment statefulset; do
+            for name in $(kubectl get "$kind" -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "  Waiting for $kind/$name rollout..."
+              kubectl rollout status "$kind/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+                echo "    Rollout status check timed out for $kind/$name (will retry in pod wait)"
+            done
+          done
+          # Also wait for LeaderWorkerSet rollouts, since they were patched above.
+          for name in $(kubectl get leaderworkersets -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "  Waiting for leaderworkerset/$name rollout..."
+            kubectl rollout status "leaderworkerset/$name" -n "$NAMESPACE" --timeout=10m 2>/dev/null || \
+              echo "    Rollout status check failed for leaderworkerset/$name (kubectl may not support rollout for this resource; will rely on pod wait)"
+          done
+          echo "Rollouts stabilized"
+
       - name: Show deployment status
         run: |
           echo "=== Deployments ==="


### PR DESCRIPTION
## Summary
- Adds `kubectl rollout status` after priority class patching in all 3 reusable workflows
- Prevents the rolling update race condition that caused IS and PPC nightly failures

## Problem
The priority patch (`priorityClassName: nightly-gpu-critical`) triggers a Deployment rolling update:
1. Helmfile deploys pods → ReplicaSet A starts loading models
2. Priority patch changes spec → Kubernetes creates ReplicaSet B
3. `kubectl wait --all` captures pods from BOTH ReplicaSets
4. Old ReplicaSet A pods get deleted → "NotFound" errors
5. New ReplicaSet B pods start model loading from scratch
6. 30min timeout exceeded

Both IS OCP and PPC OCP failed with this exact pattern tonight.

## Fix
After priority patching, run `kubectl rollout status` for each deployment/statefulset to wait for the rolling update to complete. Only then proceed to `kubectl wait --for=condition=Ready --all`. This ensures only the final ReplicaSet's pods are tracked.

## Test plan
- [ ] Trigger IS OCP nightly — verify rollout completes before pod wait
- [ ] Trigger PPC OCP nightly — same verification
- [ ] Check logs show "Rollouts stabilized" message before pod readiness check