### PR TITLE
🐛 Use Recreate strategy for GPU deployments during nightly priority patching

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -643,8 +643,15 @@ jobs:
                 jq '[.spec.template.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
               if [ "$GPU_REQ" -gt 0 ]; then
                 echo "  Patching $kind/$name (requests $GPU_REQ GPU(s))..."
-                kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
-                  '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                if [ "$kind" = "deployment" ]; then
+                  # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
+                  # With RollingUpdate, new pods can't start because old pods hold the GPUs.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                else
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                fi
               fi
             done
           done

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -472,8 +472,15 @@ jobs:
                 jq '[.spec.template.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
               if [ "$GPU_REQ" -gt 0 ]; then
                 echo "  Patching $kind/$name (requests $GPU_REQ GPU(s))..."
-                kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
-                  '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                if [ "$kind" = "deployment" ]; then
+                  # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
+                  # With RollingUpdate, new pods can't start because old pods hold the GPUs.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                else
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                fi
               fi
             done
           done

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -660,8 +660,15 @@ jobs:
                 jq '[.spec.template.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
               if [ "$GPU_REQ" -gt 0 ]; then
                 echo "  Patching $kind/$name (requests $GPU_REQ GPU(s))..."
-                kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
-                  '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                if [ "$kind" = "deployment" ]; then
+                  # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
+                  # With RollingUpdate, new pods can't start because old pods hold the GPUs.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                else
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                    '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                fi
               fi
             done
           done


### PR DESCRIPTION
## Summary

- Fixes GPU deployment rolling update deadlock during nightly E2E priority patching
- When we patch GPU deployments with `priorityClassName: nightly-gpu-critical`, the pod template change triggers a rolling update. With the default `RollingUpdate` strategy, new pods can't start because old pods still hold the GPUs — causing a deadlock where the rollout never completes
- Changes the strategy to `Recreate` for GPU **deployments** only, which kills all old pods first, freeing GPU resources for new pods
- StatefulSets retain the existing patch (no strategy change) since they have different update semantics

## Changes

All 3 reusable workflows updated:
- `reusable-nightly-e2e-openshift-helmfile.yaml`
- `reusable-nightly-e2e-cks-helmfile.yaml`
- `reusable-nightly-e2e-gke-helmfile.yaml`

## Root cause

From IS OCP nightly run 22188964218:
1. Helmfile deploys with `RollingUpdate` strategy (default)
2. Priority patching changes the pod template → triggers rolling update
3. New pods need GPUs but old pods still hold them → new pods stuck `Pending`
4. Old pods won't terminate until new pods are ready → deadlock
5. `kubectl rollout status` times out at 10min, then pod-wait times out at 30min

## Fix

For GPU deployments, combine `strategy.type: Recreate` with the priority patch in a single `kubectl patch` call:
```bash
kubectl patch deployment $name -n $NAMESPACE --type=strategic -p \
  '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
```

## Test plan

- [ ] Trigger IS OCP nightly — should no longer deadlock at rolling update
- [ ] Verify rollout completes within timeout
- [ ] Verify pods come up with correct priorityClassName