### PR TITLE
🐛 Fix Recreate strategy patch: use merge patch to remove rollingUpdate config

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -646,7 +646,9 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
+                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
                     '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -475,7 +475,9 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
+                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
                     '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -663,7 +663,9 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
+                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
+                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
                     '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \


### PR DESCRIPTION
## Summary

- Fixes the Recreate strategy patch from PR #48 which failed because `--type=strategic` preserves the existing `rollingUpdate` field
- Kubernetes rejects `strategy.type: Recreate` when `rollingUpdate` config is present
- Switches to `--type=merge` which replaces the entire `strategy` object, removing the conflicting `rollingUpdate` config

## Root cause

From IS OCP nightly run 22190965450:
```
The Deployment "ms-inference-scheduling-llm-d-modelservice-decode" is invalid: 
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

Strategic merge patch merges into existing objects, so the deployment's existing `rollingUpdate` settings were preserved alongside the new `type: Recreate` — an invalid combination.

## Fix

Change `--type=strategic` → `--type=merge` for the deployment Recreate patch only. Merge patch replaces the entire `strategy` object:
```bash
kubectl patch deployment $name -n $NAMESPACE --type=merge -p \
  '{"spec":{"strategy":{"type":"Recreate"},...}}'
```

## Test plan

- [ ] Trigger IS OCP nightly — patch should succeed, pods should roll out via Recreate