### PR TITLE
🐛 Fix Recreate patch: explicitly null rollingUpdate field

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -646,10 +646,10 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
-                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  # Use merge patch with rollingUpdate:null to clear the existing rollingUpdate
+                  # config, which Kubernetes rejects when strategy type is Recreate.
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
-                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                    '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
                     '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -475,10 +475,10 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
-                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  # Use merge patch with rollingUpdate:null to clear the existing rollingUpdate
+                  # config, which Kubernetes rejects when strategy type is Recreate.
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
-                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                    '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
                     '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -663,10 +663,10 @@ jobs:
                 if [ "$kind" = "deployment" ]; then
                   # Use Recreate strategy for GPU deployments to avoid rolling update deadlock.
                   # With RollingUpdate, new pods can't start because old pods hold the GPUs.
-                  # Use merge patch (not strategic) so it replaces the strategy object entirely,
-                  # removing any existing rollingUpdate config that conflicts with Recreate.
+                  # Use merge patch with rollingUpdate:null to clear the existing rollingUpdate
+                  # config, which Kubernetes rejects when strategy type is Recreate.
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=merge -p \
-                    '{"spec":{"strategy":{"type":"Recreate"},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
+                    '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null},"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'
                 else
                   kubectl patch "$kind" "$name" -n "$NAMESPACE" --type=strategic -p \
                     '{"spec":{"template":{"spec":{"priorityClassName":"nightly-gpu-critical"}}}}'


### PR DESCRIPTION
## Summary

Follow-up to #49. JSON merge patch merges at each level rather than replacing objects, so `rollingUpdate` was preserved even with `--type=merge`. Adding `"rollingUpdate": null` explicitly removes the field.

## Error from run 22193238791
```
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'
```

## Fix
```json
{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null},...}}
```