### PR TITLE
🐛 Fix nightly WVA E2E tests missing ENVIRONMENT and USE_SIMULATOR env vars

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -801,6 +801,9 @@ jobs:
           GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
           DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          ENVIRONMENT: kubernetes
+          USE_SIMULATOR: "false"
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }}) on CKS..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
@@ -809,6 +812,9 @@ jobs:
           echo "  MODEL_ID: $MODEL_ID"
           echo "  REQUEST_RATE: $REQUEST_RATE"
           echo "  NUM_PROMPTS: $NUM_PROMPTS"
+          echo "  ENVIRONMENT: $ENVIRONMENT"
+          echo "  USE_SIMULATOR: $USE_SIMULATOR"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
           cd _caller
           make ${{ inputs.test_target }}
 

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -827,6 +827,9 @@ jobs:
           GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
           DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          ENVIRONMENT: openshift
+          USE_SIMULATOR: "false"
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }})..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
@@ -836,6 +839,9 @@ jobs:
           echo "  MODEL_ID: $MODEL_ID"
           echo "  REQUEST_RATE: $REQUEST_RATE"
           echo "  NUM_PROMPTS: $NUM_PROMPTS"
+          echo "  ENVIRONMENT: $ENVIRONMENT"
+          echo "  USE_SIMULATOR: $USE_SIMULATOR"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
           cd _caller
           make ${{ inputs.test_target }}
 


### PR DESCRIPTION
## Problem

The WVA nightly E2E tests on both OCP and CKS have been failing since Feb 28, 2026 (3 consecutive nights). The tests fail at the "Run WVA E2E tests" step with the WVA controller making "no-change" decisions and never scaling up.

## Root Cause

The "Run WVA E2E tests" step in both reusable workflows was missing three critical environment variables:

| Variable | Expected | Actual (default) | Impact |
|----------|----------|-------------------|--------|
| `ENVIRONMENT` | `openshift` / `kubernetes` | `kind-emulator` | Tests treat cluster as local Kind |
| `USE_SIMULATOR` | `false` | `true` | Tests create simulated model pods instead of using real vLLM |
| `CONTROLLER_INSTANCE` | `wva-workload-autoscaling` | `""` (empty) | Tests create VAs without instance label, controller may ignore them |

The Makefile's `test-e2e-full` target explicitly sets `ENVIRONMENT=$(ENVIRONMENT)` and `USE_SIMULATOR=$(USE_SIMULATOR)` on the `go test` command line. Since these env vars weren't provided by the workflow step, Make used its defaults (`kind-emulator` and `true`).

This caused the e2e tests to create **simulated** model service pods on **real GPU clusters**, resulting in the WVA controller not detecting saturation properly and never triggering scale-up.

## Why PR CI passes but nightly fails

The PR CI workflow in `llm-d/llm-d-workload-variant-autoscaler` (`ci-e2e-openshift.yaml`) manages its own deployment and sets `ENVIRONMENT=openshift` and `USE_SIMULATOR=false` correctly. The nightly uses these reusable workflows which were missing those env vars.

## Fix

Add the three missing env vars to the "Run WVA E2E tests" step in both:
- `reusable-nightly-e2e-openshift-helmfile.yaml` (ENVIRONMENT=openshift)
- `reusable-nightly-e2e-cks-helmfile.yaml` (ENVIRONMENT=kubernetes)

## Timeline
- **Feb 25**: Saturation optimizer PR #771 merged in WVA repo
- **Feb 27**: PR #795 in llm-d/llm-d switched nightly from `test-e2e-openshift` to `test-e2e-full`
- **Feb 28+**: All nightly runs fail (the old `test-e2e-openshift` target may have had different defaults or didn't use the unified test suite)