### PR TITLE
⚠️ fix: skip infra VA/HPA in nightly E2E to avoid saturation engine conflict

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -576,8 +576,12 @@ jobs:
           DEPLOY_WVA: "true"
           DEPLOY_PROMETHEUS: "true"
           DEPLOY_PROMETHEUS_ADAPTER: "true"
-          DEPLOY_VA: "true"
-          DEPLOY_HPA: "true"
+          # Skip infra VA/HPA — the E2E tests create their own VA+HPA targeting
+          # their own deployments. The infra VA adds a second idle pod to the
+          # saturation analysis group, diluting KV cache metrics and preventing
+          # scale-up from triggering (matches PR CI approach).
+          DEPLOY_VA: "false"
+          DEPLOY_HPA: "false"
         run: |
           echo "Deploying $GUIDE_NAME via WVA install.sh on CKS..."
           echo "  MODEL_ID: $MODEL_ID"

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -598,8 +598,12 @@ jobs:
           DEPLOY_WVA: "true"
           DEPLOY_PROMETHEUS: "true"
           DEPLOY_PROMETHEUS_ADAPTER: "true"
-          DEPLOY_VA: "true"
-          DEPLOY_HPA: "true"
+          # Skip infra VA/HPA — the E2E tests create their own VA+HPA targeting
+          # their own deployments. The infra VA adds a second idle pod to the
+          # saturation analysis group, diluting KV cache metrics and preventing
+          # scale-up from triggering (matches PR CI approach).
+          DEPLOY_VA: "false"
+          DEPLOY_HPA: "false"
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
           WVA_METRICS_SECURE: "false"
         run: |


### PR DESCRIPTION
## Problem

The nightly E2E tests (OCP + CKS) create their own VA+HPA targeting test-specific deployments. When the infra VA/HPA is also deployed (`DEPLOY_VA=true`), the WVA saturation engine groups ALL VAs for the same model together.

This causes test VAs to get `MetricsAvailable=False` and `optimized=0`, making smoke test 'should scale up under load' and parallel load scale-up test fail with timeouts.

## Root Cause

From nightly logs:
```
Skipping status update for VA without accelerator info, but setting MetricsAvailable=False
  {"variant": "llm-d-nightly-wva/smoke-test-va"}
```

The infra VA adds a second idle pod to the saturation analysis group, diluting KV cache metrics and preventing scale-up from triggering.

## Fix

Set `DEPLOY_VA=false` and `DEPLOY_HPA=false` in both reusable nightly workflows, matching the PR CI approach in `ci-e2e-openshift.yaml` from `llm-d/llm-d-workload-variant-autoscaler`.

## Impact

- **Before**: 27 passed / 3 failed (after PR #68 env var fix)
- **Expected**: 29+ passed / 1 failed (scale-to-zero is a known separate issue)

## Related

- PR #68 (merged): Fixed missing env vars in nightly E2E tests
- Reference: `llm-d/llm-d-workload-variant-autoscaler/.github/workflows/ci-e2e-openshift.yaml` uses `DEPLOY_VA: false`