### PR TITLE
✨ Emit per-run image metadata as workflow artifact

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -879,6 +879,8 @@ jobs:
 
       - name: Emit image metadata
         if: always()
+        env:
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -900,13 +902,14 @@ jobs:
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
             --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -918,7 +921,7 @@ jobs:
 
       - name: Upload image metadata
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: image-metadata
           path: /tmp/image-metadata.json

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -632,13 +632,14 @@ jobs:
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
             --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -650,7 +651,7 @@ jobs:
 
       - name: Upload image metadata
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: image-metadata
           path: /tmp/image-metadata.json

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -919,6 +919,8 @@ jobs:
 
       - name: Emit image metadata
         if: always()
+        env:
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -940,13 +942,14 @@ jobs:
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
             --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -958,7 +961,7 @@ jobs:
 
       - name: Upload image metadata
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: image-metadata
           path: /tmp/image-metadata.json

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -584,6 +584,9 @@ jobs:
 
       - name: Emit image metadata
         if: always()
+        env:
+          # Legacy WVA-only workflow — WVA is always deployed
+          DEPLOY_WVA: 'true'
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -605,13 +608,14 @@ jobs:
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
             --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -623,7 +627,7 @@ jobs:
 
       - name: Upload image metadata
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: image-metadata
           path: /tmp/image-metadata.json


### PR DESCRIPTION
## Summary
- Adds an "Emit image metadata" step + artifact upload to all 4 reusable nightly E2E workflows
- After image overrides are applied (but before cleanup), the step scans the guide's values files for all container image references
- Splits images into `llmdImages` (ghcr.io/llm-d/) and `otherImages` categories
- Writes the result to `$GITHUB_STEP_SUMMARY` for human readability
- Uploads as an `image-metadata` artifact (90-day retention) for API consumption

## Why
The KubeStellar Console nightly E2E dashboard currently shows guide-level image tags (same for every dot/run). Since nightly workflows override guide YAML tags with `latest` images and the GitHub Actions API doesn't expose workflow inputs, there's no way to know what images each run actually used. This artifact provides that data per-run.

## Artifact schema
```json
{
  "guideName": "inference-scheduling",
  "imageOverride": "ghcr.io/llm-d/llm-d-cuda-dev:latest",
  "wvaImageTag": null,
  "llmdImages": {
    "llm-d-cuda-dev": "latest",
    "llm-d-inference-router": "v0.3.0"
  },
  "otherImages": {
    "envoy": "v1.31.6-gateway-api-0.3.0"
  }
}
```

## Files changed
| File | Change |
|------|--------|
| `reusable-nightly-e2e-openshift-helmfile.yaml` | +47 lines (emit + upload steps) |
| `reusable-nightly-e2e-cks-helmfile.yaml` | +47 lines |
| `reusable-nightly-e2e-gke-helmfile.yaml` | +47 lines |
| `reusable-nightly-e2e-openshift.yaml` | +47 lines |

## Test plan
- [ ] Verify YAML is valid (done locally via `yaml.safe_load`)
- [ ] Trigger a manual workflow run on one guide to verify the artifact is created
- [ ] Verify the step summary shows the image metadata table
- [ ] Verify the artifact JSON is downloadable and correctly structured