### PR TITLE
⚡ Move image metadata emission earlier in nightly workflows

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -718,6 +718,58 @@ jobs:
           echo "=== Gateways ==="
           kubectl get gateway -n "$NAMESPACE" || true
 
+      # Emit image metadata early so the artifact is available while tests run.
+      # Images are fully resolved after override+deploy — no need to wait for tests.
+      - name: Emit image metadata
+        if: always()
+        env:
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
       - name: Wait for pods to be ready
         env:
           POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
@@ -876,56 +928,6 @@ jobs:
             echo "| Prompts | $NUM_PROMPTS |" >> $GITHUB_STEP_SUMMARY
             echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
           fi
-
-      - name: Emit image metadata
-        if: always()
-        env:
-          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
-        run: |
-          set -euo pipefail
-          METADATA_FILE=/tmp/image-metadata.json
-          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
-          LLMD_IMAGES='{}'
-          OTHER_IMAGES='{}'
-          if [ -d "$SCAN_PATH" ]; then
-            while IFS= read -r ref; do
-              [ -z "$ref" ] && continue
-              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
-              tag=$(echo "$ref" | sed 's/.*://')
-              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
-                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              else
-                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              fi
-            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
-          fi
-          jq -n \
-            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
-            --arg guideName "$GUIDE_NAME" \
-            --argjson llmdImages "$LLMD_IMAGES" \
-            --argjson otherImages "$OTHER_IMAGES" \
-            '{
-              guideName: $guideName,
-              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
-              llmdImages: $llmdImages,
-              otherImages: $otherImages
-            }' > "$METADATA_FILE"
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload image metadata
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: image-metadata
-          path: /tmp/image-metadata.json
-          retention-days: 90
 
       - name: Collect pod logs
         if: always()

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -543,6 +543,56 @@ jobs:
           echo "=== Gateways ==="
           kubectl get gateway -n "$NAMESPACE" || true
 
+      # Emit image metadata early so the artifact is available while tests run.
+      # Images are fully resolved after override+deploy — no need to wait for tests.
+      - name: Emit image metadata
+        if: always()
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
       - name: Wait for pods to be ready
         env:
           POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
@@ -608,54 +658,6 @@ jobs:
           echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
           echo "| Accelerator | $ACCELERATOR_TYPE |" >> $GITHUB_STEP_SUMMARY
           echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
-
-      - name: Emit image metadata
-        if: always()
-        run: |
-          set -euo pipefail
-          METADATA_FILE=/tmp/image-metadata.json
-          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
-          LLMD_IMAGES='{}'
-          OTHER_IMAGES='{}'
-          if [ -d "$SCAN_PATH" ]; then
-            while IFS= read -r ref; do
-              [ -z "$ref" ] && continue
-              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
-              tag=$(echo "$ref" | sed 's/.*://')
-              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
-                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              else
-                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              fi
-            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
-          fi
-          jq -n \
-            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
-            --arg guideName "$GUIDE_NAME" \
-            --argjson llmdImages "$LLMD_IMAGES" \
-            --argjson otherImages "$OTHER_IMAGES" \
-            '{
-              guideName: $guideName,
-              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
-              llmdImages: $llmdImages,
-              otherImages: $otherImages
-            }' > "$METADATA_FILE"
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload image metadata
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: image-metadata
-          path: /tmp/image-metadata.json
-          retention-days: 90
 
       - name: Collect pod logs
         if: always()

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -735,6 +735,58 @@ jobs:
           echo "=== Gateways ==="
           kubectl get gateway -n "$NAMESPACE" || true
 
+      # Emit image metadata early so the artifact is available while tests run.
+      # Images are fully resolved after override+deploy — no need to wait for tests.
+      - name: Emit image metadata
+        if: always()
+        env:
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
       - name: Wait for pods to be ready
         env:
           POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
@@ -916,56 +968,6 @@ jobs:
             echo "| Prompts | $NUM_PROMPTS |" >> $GITHUB_STEP_SUMMARY
             echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
           fi
-
-      - name: Emit image metadata
-        if: always()
-        env:
-          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
-        run: |
-          set -euo pipefail
-          METADATA_FILE=/tmp/image-metadata.json
-          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
-          LLMD_IMAGES='{}'
-          OTHER_IMAGES='{}'
-          if [ -d "$SCAN_PATH" ]; then
-            while IFS= read -r ref; do
-              [ -z "$ref" ] && continue
-              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
-              tag=$(echo "$ref" | sed 's/.*://')
-              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
-                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              else
-                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              fi
-            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
-          fi
-          jq -n \
-            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
-            --arg guideName "$GUIDE_NAME" \
-            --argjson llmdImages "$LLMD_IMAGES" \
-            --argjson otherImages "$OTHER_IMAGES" \
-            '{
-              guideName: $guideName,
-              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
-              llmdImages: $llmdImages,
-              otherImages: $otherImages
-            }' > "$METADATA_FILE"
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload image metadata
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: image-metadata
-          path: /tmp/image-metadata.json
-          retention-days: 90
 
       - name: Collect pod logs
         if: always()

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -426,6 +426,59 @@ jobs:
           kubectl label namespace "$WVA_NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
           echo "Namespace labels applied"
 
+      # Emit image metadata early so the artifact is available while tests run.
+      # Images are fully resolved after override+deploy — no need to wait for tests.
+      - name: Emit image metadata
+        if: always()
+        env:
+          # Legacy WVA-only workflow — WVA is always deployed
+          DEPLOY_WVA: 'true'
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
       - name: Wait for infrastructure to be ready
         run: |
           echo "Waiting for deployments to be ready..."
@@ -581,57 +634,6 @@ jobs:
           echo "| llm-d Release | $LLM_D_RELEASE |" >> $GITHUB_STEP_SUMMARY
           echo "| Request Rate | $REQUEST_RATE req/s |" >> $GITHUB_STEP_SUMMARY
           echo "| Prompts | $NUM_PROMPTS |" >> $GITHUB_STEP_SUMMARY
-
-      - name: Emit image metadata
-        if: always()
-        env:
-          # Legacy WVA-only workflow — WVA is always deployed
-          DEPLOY_WVA: 'true'
-        run: |
-          set -euo pipefail
-          METADATA_FILE=/tmp/image-metadata.json
-          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
-          LLMD_IMAGES='{}'
-          OTHER_IMAGES='{}'
-          if [ -d "$SCAN_PATH" ]; then
-            while IFS= read -r ref; do
-              [ -z "$ref" ] && continue
-              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
-              tag=$(echo "$ref" | sed 's/.*://')
-              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
-                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              else
-                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
-              fi
-            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
-          fi
-          jq -n \
-            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
-            --arg guideName "$GUIDE_NAME" \
-            --argjson llmdImages "$LLMD_IMAGES" \
-            --argjson otherImages "$OTHER_IMAGES" \
-            '{
-              guideName: $guideName,
-              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
-              llmdImages: $llmdImages,
-              otherImages: $otherImages
-            }' > "$METADATA_FILE"
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload image metadata
-        if: always()
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: image-metadata
-          path: /tmp/image-metadata.json
-          retention-days: 90
 
       - name: Cleanup infrastructure
         if: always() && inputs.skip_cleanup == false


### PR DESCRIPTION
## Summary

- Moves the "Emit image metadata" and "Upload image metadata" steps from after tests to right after deployment in all 4 reusable nightly workflows
- Image tags are fully resolved after override+deploy — no need to wait for the 15-30 min test phase
- The console can now show per-run images as soon as the deployment completes, even while tests are still running

## Changes

All 4 reusable workflows updated:
- `reusable-nightly-e2e-openshift-helmfile.yaml` — moved after "Show deployment status"
- `reusable-nightly-e2e-gke-helmfile.yaml` — moved after "Show deployment status"
- `reusable-nightly-e2e-cks-helmfile.yaml` — moved after "Show deployment status"
- `reusable-nightly-e2e-openshift.yaml` — moved after "Deploy infrastructure"

## Test plan

- [ ] Trigger IS nightly on OCP and verify image-metadata artifact appears early (during test phase)
- [ ] Verify artifact JSON content is correct