### PR TITLE
🐛 Fix CONSUMING_REPOS to match actual org repos

### DIFF
--- a/.github/workflows/sync-caller-workflows.yml
+++ b/.github/workflows/sync-caller-workflows.yml
@@ -33,28 +33,24 @@ permissions:
 
 env:
   # All non-archived repos across llm-d and llm-d-incubation orgs.
-  # Excludes: llm-d-deployer (archived), llm-d-model-service (archived),
-  # llm-d-routing-sidecar (archived), llm-d-infra (this repo — source of truth).
+  # Excludes: llm-d-infra (source of truth), .github, templates, github.io, llm-d-incubation/llm-d-infra.
   CONSUMING_REPOS: |
     llm-d/llm-d
     llm-d/llm-d-benchmark
-    llm-d/llm-d-docs
     llm-d/llm-d-inference-scheduler
     llm-d/llm-d-inference-sim
-    llm-d/llm-d-leaderboard
-    llm-d/llm-d-net
-    llm-d/llm-d-operator
+    llm-d/llm-d-kv-cache
+    llm-d/llm-d-pd-utils
+    llm-d/llm-d-prism
     llm-d/llm-d-workload-variant-autoscaler
-    llm-d/lora-manager
-    llm-d/lora-reference-store
-    llm-d/prompt-manager
-    llm-d-incubation/llm-d-ci-templates
-    llm-d-incubation/llm-d-helm-charts
-    llm-d-incubation/llm-d-performance-benchmarks
-    llm-d-incubation/llm-d-prerelease
-    llm-d-incubation/llm-d-vllm-fork
-    llm-d-incubation/sidecar
-    llm-d-incubation/workload-benchmarks
+    llm-d-incubation/batch-gateway
+    llm-d-incubation/hermes
+    llm-d-incubation/ig-wva
+    llm-d-incubation/llm-d-async
+    llm-d-incubation/llm-d-ci
+    llm-d-incubation/llm-d-fast-model-actuation
+    llm-d-incubation/llm-d-modelservice
+    llm-d-incubation/secure-inference
 
   GH_AW_WORKFLOWS: "upstream-monitor link-checker typo-checker"
   SYNC_BRANCH: "sync/gh-aw-workflows"


### PR DESCRIPTION
## Summary
- The sync workflow had 19 repo names in CONSUMING_REPOS, but 14 don't exist
- Updated to the 16 actual non-archived repos across llm-d and llm-d-incubation orgs
- Excludes: llm-d-infra (source of truth), .github, templates, github.io

## Repos (16 total)
**llm-d (8):** llm-d, llm-d-benchmark, llm-d-inference-scheduler, llm-d-inference-sim, llm-d-kv-cache, llm-d-pd-utils, llm-d-prism, llm-d-workload-variant-autoscaler

**llm-d-incubation (8):** batch-gateway, hermes, ig-wva, llm-d-async, llm-d-ci, llm-d-fast-model-actuation, llm-d-modelservice, secure-inference