### PR TITLE
🐛 Fix sync workflow: handle errors per-repo without aborting

### DIFF
--- a/.github/workflows/sync-caller-workflows.yml
+++ b/.github/workflows/sync-caller-workflows.yml
@@ -34,7 +34,7 @@ permissions:
 env:
   # All non-archived repos across llm-d and llm-d-incubation orgs.
   # Excludes: llm-d-infra (source of truth), .github, templates, github.io,
-  # llm-d-incubation/llm-d-infra, llm-d-prism (empty — see issue #2).
+  # llm-d-incubation/llm-d-infra.
   CONSUMING_REPOS: |
     llm-d/llm-d
     llm-d/llm-d-benchmark
@@ -42,6 +42,7 @@ env:
     llm-d/llm-d-inference-sim
     llm-d/llm-d-kv-cache
     llm-d/llm-d-pd-utils
+    llm-d/llm-d-prism
     llm-d/llm-d-workload-variant-autoscaler
     llm-d-incubation/batch-gateway
     llm-d-incubation/hermes


### PR DESCRIPTION
## Summary
The sync workflow failed because `set -euo pipefail` caused one repo failure to abort the entire run. `llm-d-prism` (empty repo) failed on `gh pr create`, which killed the script before processing any llm-d-incubation repos.

## Changes
- Remove `set -e` — use per-repo error handling instead
- Wrap push/PR creation in a subshell so failures are contained
- Skip empty repos (no commits) that can't accept PRs
- Show clone errors in logs (was suppressed by `2>/dev/null`)
- Track and report failure count in step summary
- Only fail the job if ALL repos fail

## Test plan
- Trigger `workflow_dispatch` and verify all 16 repos are processed
- Verify empty repos (like llm-d-prism) are skipped gracefully
- Verify llm-d-incubation repos get PRs