### PR TITLE
🐛 Enable scale-from-zero in WVA nightly E2E on CKS and OCP

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -576,6 +576,9 @@ jobs:
           DEPLOY_WVA: "true"
           DEPLOY_PROMETHEUS: "true"
           DEPLOY_PROMETHEUS_ADAPTER: "true"
+          # KEDA enables ScaledObject with minReplicas=0 for scale-from-zero tests
+          # (CKS does not have the HPAScaleToZero feature gate, so standard HPA rejects minReplicas=0)
+          SCALER_BACKEND: keda
           # Skip infra VA/HPA — the E2E tests create their own VA+HPA targeting
           # their own deployments. The infra VA adds a second idle pod to the
           # saturation analysis group, diluting KV cache metrics and preventing
@@ -857,14 +860,19 @@ jobs:
           GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
           DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
           ENVIRONMENT: kubernetes
           USE_SIMULATOR: "false"
           CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
+          SCALER_BACKEND: keda
+          SCALE_TO_ZERO_ENABLED: "true"
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }}) on CKS..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
           echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
           echo "  DEPLOYMENT: $DEPLOYMENT"
+          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
+          echo "  SCALER_BACKEND: $SCALER_BACKEND"
           echo "  MODEL_ID: $MODEL_ID"
           echo "  REQUEST_RATE: $REQUEST_RATE"
           echo "  NUM_PROMPTS: $NUM_PROMPTS"

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -595,6 +595,7 @@ jobs:
           DECODE_REPLICAS: "1"
           WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
           RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
+          SCALER_BACKEND: keda
           DEPLOY_WVA: "true"
           DEPLOY_PROMETHEUS: "true"
           DEPLOY_PROMETHEUS_ADAPTER: "true"
@@ -883,14 +884,18 @@ jobs:
           GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
           DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
           ENVIRONMENT: openshift
           USE_SIMULATOR: "false"
           CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
+          SCALER_BACKEND: keda
+          SCALE_TO_ZERO_ENABLED: "true"
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }})..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
           echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
           echo "  DEPLOYMENT: $DEPLOYMENT"
+          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
           echo "  GATEWAY_NAME: $GATEWAY_NAME"
           echo "  MODEL_ID: $MODEL_ID"
           echo "  REQUEST_RATE: $REQUEST_RATE"
@@ -898,6 +903,8 @@ jobs:
           echo "  ENVIRONMENT: $ENVIRONMENT"
           echo "  USE_SIMULATOR: $USE_SIMULATOR"
           echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
+          echo "  SCALER_BACKEND: $SCALER_BACKEND"
+          echo "  SCALE_TO_ZERO_ENABLED: $SCALE_TO_ZERO_ENABLED"
           cd _caller
           make ${{ inputs.test_target }}
 


### PR DESCRIPTION
## Summary
- Pass `EPP_SERVICE_NAME` matching GAIE helm release naming convention (`gaie-<guide_name>-epp`)
- Add `SCALER_BACKEND: keda` to install and test steps on both CKS and OCP workflows
- Add `SCALE_TO_ZERO_ENABLED: "true"` to test steps on both platforms
- Add debug echo lines for new env vars

## Context
The WVA scale-from-zero test needs KEDA (for `ScaledObject` with `minReplicas=0`) since `HPAScaleToZero` feature gate is disabled on both CKS and OCP. KEDA is pre-installed on both clusters.

Companion PR: https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/865

## Test plan
- [ ] CKS nightly E2E: scale-from-zero test passes
- [ ] OCP nightly E2E: scale-from-zero test passes