### PR TITLE
🐛 Add KEDA_NAMESPACE for CKS and OCP nightly E2E

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -866,6 +866,7 @@ jobs:
           CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
           SCALER_BACKEND: keda
           SCALE_TO_ZERO_ENABLED: "true"
+          KEDA_NAMESPACE: keda
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }}) on CKS..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -890,6 +890,7 @@ jobs:
           CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
           SCALER_BACKEND: keda
           SCALE_TO_ZERO_ENABLED: "true"
+          KEDA_NAMESPACE: openshift-keda
         run: |
           echo "Running WVA E2E tests (${{ inputs.test_target }})..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"


### PR DESCRIPTION
## Summary
- Pass `KEDA_NAMESPACE: keda` in CKS workflow (KEDA installed via upstream helm)
- Pass `KEDA_NAMESPACE: openshift-keda` in OCP workflow (KEDA via CMA operator)

## Context
Follow-up to #87. The WVA E2E smoke test checks KEDA operator readiness in `cfg.KEDANamespace` which defaults to `keda-system`. Neither CKS nor OCP use that namespace.

## Test plan
- [ ] CKS nightly E2E: KEDA operator readiness check passes
- [ ] OCP nightly E2E: KEDA operator readiness check passes