### PR TITLE
🐛 Fix typos binary extraction in nightly org-wide checks

### DIFF
--- a/.github/workflows/nightly-org-checks.yml
+++ b/.github/workflows/nightly-org-checks.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           TYPOS_VERSION="v1.31.1"
           curl -fsSL "https://github.com/crate-ci/typos/releases/download/${TYPOS_VERSION}/typos-${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-            | tar xz -C /usr/local/bin typos
+            | tar xz -C /usr/local/bin ./typos
 
       - name: Run typo check
         if: inputs.skip_typos != true


### PR DESCRIPTION
## Summary
- Fix `tar: typos: Not found in archive` error in nightly org-wide checks
- The typos v1.31.1 tar archive contains `./typos` (with `./` prefix), not bare `typos`
- Change tar extract path from `typos` to `./typos`

## Test plan
- [ ] Retrigger `Nightly Org-Wide Checks` after merge — all check-repo jobs should pass the typos install step