### PR TITLE
🐛 Add POOL_GROUP and ENABLE_SCALE_TO_ZERO for WVA nightly E2E

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -579,6 +579,9 @@ jobs:
           # KEDA enables ScaledObject with minReplicas=0 for scale-from-zero tests
           # (CKS does not have the HPAScaleToZero feature gate, so standard HPA rejects minReplicas=0)
           SCALER_BACKEND: keda
+          ENABLE_SCALE_TO_ZERO: "true"
+          # InferencePool API group — v1 on CKS (GAIE helm deploys to inference.networking.k8s.io)
+          POOL_GROUP: inference.networking.k8s.io
           # Skip infra VA/HPA — the E2E tests create their own VA+HPA targeting
           # their own deployments. The infra VA adds a second idle pod to the
           # saturation analysis group, diluting KV cache metrics and preventing

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -596,6 +596,9 @@ jobs:
           WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
           RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
           SCALER_BACKEND: keda
+          ENABLE_SCALE_TO_ZERO: "true"
+          # InferencePool API group — v1 on OCP (GAIE helm deploys to inference.networking.k8s.io)
+          POOL_GROUP: inference.networking.k8s.io
           DEPLOY_WVA: "true"
           DEPLOY_PROMETHEUS: "true"
           DEPLOY_PROMETHEUS_ADAPTER: "true"


### PR DESCRIPTION
## Summary
- Pass `ENABLE_SCALE_TO_ZERO: "true"` and `POOL_GROUP: inference.networking.k8s.io` to the WVA install step on both CKS and OCP nightly E2E workflows
- `ENABLE_SCALE_TO_ZERO` is needed so `install.sh` sets `wva.scaleToZero=true` in the helm values, enabling the scale-from-zero engine
- `POOL_GROUP` is needed because auto-detection of the InferencePool API group fails when the pool isn't yet created at detection time; passing it explicitly avoids the race condition

Follows up on #87 (enable scale-from-zero) and #88 (KEDA_NAMESPACE).

## Test plan
- [x] Verified KEDA is installed on CKS (`keda` namespace) and OCP (`openshift-keda` namespace)
- [ ] CKS nightly E2E passes scale-from-zero test
- [ ] OCP nightly E2E passes scale-from-zero test