### PR TITLE
🐛 Fix lychee download URL in nightly org checks

### DIFF
--- a/.github/workflows/nightly-org-checks.yml
+++ b/.github/workflows/nightly-org-checks.yml
@@ -209,9 +209,9 @@ jobs:
         if: inputs.skip_links != true
         id: links
         run: |
-          # Install lychee
-          LYCHEE_VERSION="v0.18.0"
-          curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+          # Install lychee (release tags are prefixed with "lychee-")
+          LYCHEE_VERSION="v0.23.0"
+          curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
             | tar xz -C /usr/local/bin lychee
 
           lychee --no-progress \


### PR DESCRIPTION
## Summary

- Fix the lychee binary download URL in the nightly org-wide checks workflow
- Release tags use a `lychee-` prefix (e.g. `lychee-v0.23.0`), but the workflow was using bare version tags (`v0.18.0`), causing a **404 on every link-check job** across all repos
- Bumps lychee from v0.18.0 to v0.23.0 (latest)

This has been failing every night since at least March 7. The "Create typo issue" failures are a separate token permissions issue (`ORG_GITHUB_TOKEN` lacks `issues:write` on some repos) — not addressed here.

## Test plan

- [ ] Trigger workflow manually on a single repo: `workflow_dispatch` with `repos: llm-d/llm-d-infra, skip_typos: true, skip_upstream: true`
- [ ] Verify the link check step installs lychee successfully (no 404)
- [ ] Verify broken link count is reported in the summary