### PR TITLE
🐛 Fix upstream issue current version showing null

### DIFF
--- a/.github/workflows/nightly-org-checks.yml
+++ b/.github/workflows/nightly-org-checks.yml
@@ -335,7 +335,7 @@ jobs:
           fi
 
           # Parse changes from JSON
-          jq -r '.changes[] | "\(.name)|\(.current_version)|\(.latest_version)|\(.release_url // "")"' \
+          jq -r '.changes[] | "\(.name)|\(.current_pin)|\(.latest_version)|\(.release_url // "")"' \
             /tmp/upstream-check-results.json 2>/dev/null | while IFS='|' read -r name current latest url; do
             [ -z "$name" ] && continue
 


### PR DESCRIPTION
## Summary

- Fix field name mismatch: workflow read `.current_version` but `check-upstream-releases.sh` writes `.current_pin`
- This caused all upstream update issues to display `null -> <latest>` instead of `v1.2.3 -> v1.3.0`
- One-character fix: `current_version` → `current_pin` in the jq expression

## Test plan

- [ ] Trigger workflow with `repos: llm-d/llm-d-benchmark, skip_typos: true, skip_links: true`
- [ ] Verify upstream issues show actual current version instead of `null`