### PR TITLE
Add lifecycle/frozen label to exempt from stale bot

### DIFF
--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -2,6 +2,9 @@
 # Marks issues stale after 90d, rotten after 15d more, closed after 15d more
 # Marks PRs stale after 21d, rotten after 7d more, closed after 7d more
 #
+# To permanently exempt an issue or PR from the stale lifecycle,
+# add the `lifecycle/frozen` label.
+#
 # Usage in consuming repo:
 #   name: Mark Stale Issues
 #   on:
@@ -45,17 +48,17 @@ jobs:
           days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
           days-before-close: -1
           stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/rotten'
+          exempt-issue-labels: 'lifecycle/rotten,lifecycle/frozen'
           stale-issue-message: >-
             This issue is marked as stale after ${{ inputs.days-before-issue-stale }}d of inactivity.
             After an additional 30d of inactivity (15d to become rotten, then 15d more), it will be closed.
-            To prevent this issue from being closed, add a comment or remove the `lifecycle/stale` label.
+            To prevent this, add a comment, remove the `lifecycle/stale` label, or add the `lifecycle/frozen` label.
           stale-pr-label: 'lifecycle/stale'
-          exempt-pr-labels: 'lifecycle/rotten'
+          exempt-pr-labels: 'lifecycle/rotten,lifecycle/frozen'
           stale-pr-message: >-
             This PR is marked as stale after ${{ inputs.days-before-pr-stale }}d of inactivity.
             After an additional 14d of inactivity (7d to become rotten, then 7d more), it will be closed.
-            To prevent this PR from being closed, add a comment or remove the `lifecycle/stale` label.
+            To prevent this, add a comment, remove the `lifecycle/stale` label, or add the `lifecycle/frozen` label.
 
       - name: Mark items rotten
         uses: actions/stale@v10
@@ -66,6 +69,8 @@ jobs:
           stale-issue-label: 'lifecycle/rotten'
           stale-pr-label: 'lifecycle/rotten'
           only-labels: 'lifecycle/stale'
+          exempt-issue-labels: 'lifecycle/frozen'
+          exempt-pr-labels: 'lifecycle/frozen'
           labels-to-remove-when-stale: 'lifecycle/stale'
 
       - name: Close rotten items
@@ -75,6 +80,8 @@ jobs:
           days-before-issue-close: 15
           days-before-pr-close: 7
           stale-issue-label: 'lifecycle/rotten'
+          exempt-issue-labels: 'lifecycle/frozen'
+          exempt-pr-labels: 'lifecycle/frozen'
           stale-issue-message: 'This issue is being closed after extended inactivity.'
           stale-pr-label: 'lifecycle/rotten'
           stale-pr-message: 'This PR is being closed after extended inactivity.'


### PR DESCRIPTION
## Summary
- Adds `lifecycle/frozen` as an exempt label across all three stale bot passes (stale, rotten, close)
- Issues or PRs labeled `lifecycle/frozen` will never be marked stale, promoted to rotten, or auto-closed
- Updates stale bot messages to mention the `lifecycle/frozen` option
- Applies to all repos in `llm-d` and `llm-d-incubation` that use this reusable workflow

## Usage
Add the `lifecycle/frozen` label to any issue or PR that should remain open indefinitely regardless of inactivity.

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm `lifecycle/frozen` labeled issues are skipped by the stale action