### PR TITLE
fix: update install-deps.sh path after client-tools move

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml
@@ -221,7 +221,7 @@ jobs:
           fi
 
           # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
-          ./guides/prereq/client-setup/install-deps.sh
+          ./helpers/client-setup/install-deps.sh
 
           # Install jq if not present
           if ! command -v jq &>/dev/null; then

--- a/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml
@@ -194,7 +194,7 @@ jobs:
       - name: Install prerequisites (helm, helmfile, yq)
         run: |
           # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
-          ./guides/prereq/client-setup/install-deps.sh
+          ./helpers/client-setup/install-deps.sh
 
           # Install jq if not present
           if ! command -v jq &>/dev/null; then

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -231,7 +231,7 @@ jobs:
           fi
 
           # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
-          ./guides/prereq/client-setup/install-deps.sh
+          ./helpers/client-setup/install-deps.sh
 
           # Install jq if not present
           if ! command -v jq &>/dev/null; then


### PR DESCRIPTION
## Summary
- `llm-d/llm-d#1167` moved `guides/prereq/client-setup/` to `helpers/client-setup/`, but the reusable nightly e2e workflows were not updated
- All nightly e2e runs (OpenShift, GKE, CKS) fail at the "Install prerequisites" step because `./guides/prereq/client-setup/install-deps.sh` no longer exists
- Updates the path to `./helpers/client-setup/install-deps.sh` in all three reusable workflows

## Files changed
- `.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml`
- `.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml`
- `.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml`

## Test plan
- [ ] Trigger a nightly workflow dispatch and verify the "Install prerequisites" step passes