### PR TITLE
feat: migrate nightly e2e workflows to support kustomize

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -94,12 +94,17 @@ on:
         description: 'HTTPRoute file to apply (empty = skip)'
         required: false
         type: string
-        default: 'httproute.yaml'
+        default: ''
+      gateway_host:
+        description: 'Override GATEWAY_HOST for e2e-validate.sh (e.g. svc-name:port). If empty, auto-discovers from Gateway resource.'
+        required: false
+        type: string
+        default: ''
       install_gateway_provider:
         description: 'Install gateway provider prerequisites'
         required: false
         type: boolean
-        default: true
+        default: false
       pre_deploy_script:
         description: 'Script to run before deployment (e.g. slim transforms)'
         required: false
@@ -703,6 +708,7 @@ jobs:
           kubectl get pods -n "$NAMESPACE"
 
       - name: Wait for gateway to be ready
+        if: inputs.install_gateway_provider
         run: |
           GATEWAY_NAME=$(kubectl get gateway -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
           if [ -n "$GATEWAY_NAME" ]; then
@@ -787,6 +793,8 @@ jobs:
 
       - name: Run E2E validation
         if: "!inputs.deploy_wva"
+        env:
+          GATEWAY_HOST: ${{ inputs.gateway_host }}
         run: |
           echo "Running E2E validation for $GUIDE_NAME on CKS..."
           cd .github/scripts/e2e

--- a/.github/workflows/reusable-nightly-e2e-gke.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke.yaml
@@ -111,7 +111,12 @@ on:
         description: 'HTTPRoute file to apply (empty = skip)'
         required: false
         type: string
-        default: 'httproute.gke.yaml'
+        default: ''
+      gateway_host:
+        description: 'Override GATEWAY_HOST for e2e-validate.sh (e.g. svc-name:port). If empty, auto-discovers from Gateway resource.'
+        required: false
+        type: string
+        default: ''
       pre_deploy_script:
         description: 'Script to run before deployment (e.g. slim transforms)'
         required: false
@@ -582,21 +587,10 @@ jobs:
           echo "All pods in $NAMESPACE are ready"
           kubectl get pods -n "$NAMESPACE"
 
-      - name: Wait for gateway to be ready
-        run: |
-          GATEWAY_NAME=$(kubectl get gateway -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          if [ -n "$GATEWAY_NAME" ]; then
-            echo "Waiting for gateway $GATEWAY_NAME to be programmed..."
-            kubectl wait "gateway/$GATEWAY_NAME" \
-              --for=condition=Programmed=True \
-              -n "$NAMESPACE" \
-              --timeout=300s || echo "::warning::Gateway not programmed within timeout"
-            kubectl get gateway -n "$NAMESPACE"
-          else
-            echo "No gateway resource found in $NAMESPACE — skipping wait"
-          fi
 
       - name: Run E2E validation
+        env:
+          GATEWAY_HOST: ${{ inputs.gateway_host }}
         run: |
           echo "Running E2E validation for $GUIDE_NAME on GKE..."
           cd .github/scripts/e2e


### PR DESCRIPTION
- Rename *-helmfile.yaml to *.yaml to reflect agnostic deployment support.
- Add `gateway_host` input and inject `GATEWAY_HOST` to E2E validation script to support explicit endpoint specification for standalone schedulers.
- Change `install_gateway_provider` default to `false` (making gateway prerequisite optional).
- Change `httproute_file` default to `''` (empty string) to prevent missing resource errors for deployments without HTTPRoute.
