### PR TITLE
Kustomize nightly openshift

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -1,8 +1,9 @@
 name: Reusable - Nightly E2E OpenShift
 
 # Reusable workflow for nightly e2e testing of llm-d guides on OpenShift.
-# Called by individual repos (WVA, llm-d, etc.) to deploy a guide's stack
-# and run e2e tests against it.
+# Supports helmfile, kustomize, or custom deploy scripts.
+# Called by the llm-d/llm-d repo to deploy a guide's stack and run the
+# e2e-validate.sh smoke-test suite.
 #
 # Usage from a caller workflow:
 #
@@ -10,9 +11,9 @@ name: Reusable - Nightly E2E OpenShift
 #     nightly:
 #       uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
 #       with:
-#         guide_name: workload-autoscaling
-#         namespace_suffix: nightly-wva
-#         caller_repo: llm-d/llm-d-workload-variant-autoscaler
+#         guide_name: inference-scheduling
+#         namespace: llm-d-nightly-inference
+#         helmfile_env: istio
 #       secrets: inherit
 
 on:
@@ -20,38 +21,39 @@ on:
     inputs:
       # --- Guide configuration ---
       guide_name:
-        description: 'llm-d guide name (directory under guides/ in llm-d/llm-d)'
+        description: 'Guide directory name under guides/ in llm-d/llm-d'
         required: true
         type: string
-      namespace_suffix:
-        description: 'Suffix for nightly namespaces (e.g. nightly-wva -> llm-d-nightly-wva)'
-        required: true
-        type: string
-      caller_repo:
-        description: 'Calling repository (e.g. llm-d/llm-d-workload-variant-autoscaler)'
-        required: true
-        type: string
-      caller_ref:
-        description: 'Git ref to checkout for the caller repo (default: main)'
+      guide_path:
+        description: 'Override path to guide directory (default: guides/<guide_name>)'
         required: false
         type: string
-        default: 'main'
+        default: ''
+      namespace:
+        description: 'Kubernetes namespace for the deployment'
+        required: true
+        type: string
+      helmfile_env:
+        description: 'Helmfile environment (istio, kgateway, etc.)'
+        required: false
+        type: string
+        default: 'istio'
+      gateway_type:
+        description: 'Gateway provider type (istio, kgateway, agentgateway)'
+        required: false
+        type: string
+        default: 'istio'
 
-      # --- Model & accelerator ---
-      model_id:
-        description: 'Model ID'
+      # --- Repository ---
+      llm_d_ref:
+        description: 'Git ref for llm-d/llm-d checkout (default: main)'
         required: false
         type: string
-        default: 'unsloth/Meta-Llama-3.1-8B'
-      accelerator_type:
-        description: 'Accelerator type (H100, A100, L40S)'
-        required: false
-        type: string
-        default: 'A100'
+        default: ''
 
       # --- GPU requirements ---
       required_gpus:
-        description: 'Minimum GPUs required'
+        description: 'Minimum GPUs required (0 for simulated)'
         required: false
         type: number
         default: 2
@@ -65,129 +67,209 @@ on:
         required: false
         type: number
         default: 0
-
-      # --- WVA-specific (ignored for non-WVA guides) ---
-      wva_image_tag:
-        description: 'WVA image tag (only for workload-autoscaling guide)'
-        required: false
-        type: string
-        default: 'v0.5.0'
-      deploy_wva:
-        description: 'Deploy WVA controller (true for workload-autoscaling guide)'
+      allow_gpu_preemption:
+        description: 'When true, proceed with deployment even if GPUs are unavailable (relies on Kubernetes preemption of lower-priority pods)'
         required: false
         type: boolean
         default: false
 
-      # --- Test configuration ---
-      request_rate:
-        description: 'Request rate (req/s)'
+      # --- Model & accelerator ---
+      model_id:
+        description: 'Model ID (empty = auto-discover from guide)'
         required: false
         type: string
-        default: '20'
-      num_prompts:
-        description: 'Number of prompts'
+        default: ''
+      accelerator_type:
+        description: 'Accelerator type (H100, A100, L40S)'
         required: false
         type: string
-        default: '3000'
-      max_num_seqs:
-        description: 'vLLM max batch size (lower = easier to saturate)'
+        default: 'A100'
+
+      # --- Deployment configuration ---
+      helmfile_args:
+        description: 'Extra args passed to helmfile apply (e.g. --set key=val)'
         required: false
         type: string
-        default: '1'
-      hpa_stabilization_seconds:
-        description: 'HPA stabilization window in seconds'
+        default: ''
+      httproute_file:
+        description: 'HTTPRoute file to apply (empty = skip)'
         required: false
         type: string
-        default: '240'
-      test_target:
-        description: 'Make target to run tests (e.g. test-e2e-openshift)'
+        default: ''
+      gateway_host:
+        description: 'Override GATEWAY_HOST for e2e-validate.sh (e.g. svc-name:port). If empty, auto-discovers from Gateway resource.'
         required: false
         type: string
-        default: 'test-e2e-openshift'
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+        default: ''
+      install_gateway_provider:
+        description: 'Install gateway provider prerequisites'
         required: false
         type: boolean
         default: false
-
-      # --- Image override ---
+      pre_deploy_script:
+        description: 'Script to run before deployment (e.g. slim transforms)'
+        required: false
+        type: string
+        default: ''
+      custom_deploy_script:
+        description: 'Custom deploy script — replaces helmfile apply (for kustomize/helm guides)'
+        required: false
+        type: string
+        default: ''
       image_override:
         description: 'Override vLLM container image (e.g. ghcr.io/llm-d/llm-d-cuda-dev:latest)'
         required: false
         type: string
         default: ''
 
-      # --- llm-d release ---
-      llm_d_release:
-        description: 'llm-d/llm-d release/branch for guide charts'
+      # --- WVA integration (optional — enables WVA e2e tests) ---
+      deploy_wva:
+        description: 'Deploy WVA guide via make (enables WVA-specific steps)'
+        required: false
+        type: boolean
+        default: false
+      caller_repo:
+        description: 'Caller repo with deploy/install.sh and Go tests (e.g. llm-d/llm-d-workload-variant-autoscaler)'
+        required: false
+        type: string
+        default: ''
+      caller_ref:
+        description: 'Git ref for caller repo'
         required: false
         type: string
         default: 'main'
+      wva_image_tag:
+        description: 'WVA controller image tag'
+        required: false
+        type: string
+        default: 'v0.5.0'
+      test_target:
+        description: 'Make target for Go tests (e.g. test-e2e-openshift) — replaces e2e-validate.sh when set'
+        required: false
+        type: string
+        default: ''
+
+      # --- Test configuration ---
+      e2e_validate_args:
+        description: 'Extra args for e2e-validate.sh (e.g. -m model-id)'
+        required: false
+        type: string
+        default: ''
+      pod_wait_timeout:
+        description: 'Timeout for pods to become ready'
+        required: false
+        type: string
+        default: '30m'
+      pod_readiness_delay:
+        description: 'Extra delay after pods are ready (for model loading)'
+        required: false
+        type: number
+        default: 0
+
+      # --- Cleanup ---
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   nightly-e2e:
     runs-on: [self-hosted, openshift, pok-prod]
     env:
-      MODEL_ID: ${{ inputs.model_id }}
-      ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}
-      REQUEST_RATE: ${{ inputs.request_rate }}
-      NUM_PROMPTS: ${{ inputs.num_prompts }}
-      MAX_NUM_SEQS: ${{ inputs.max_num_seqs }}
-      HPA_STABILIZATION_SECONDS: ${{ inputs.hpa_stabilization_seconds }}
-      SKIP_CLEANUP: ${{ inputs.skip_cleanup && 'true' || 'false' }}
-      WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
-      LLM_D_RELEASE: ${{ inputs.llm_d_release }}
-      # Fixed namespaces for nightly
-      LLMD_NAMESPACE: llm-d-${{ inputs.namespace_suffix }}
-      WVA_NAMESPACE: llm-d-${{ inputs.namespace_suffix }}-system
-      WVA_RELEASE_NAME: wva-${{ inputs.namespace_suffix }}
       GUIDE_NAME: ${{ inputs.guide_name }}
+      GUIDE_PATH: ${{ inputs.guide_path || format('guides/{0}', inputs.guide_name) }}
+      NAMESPACE: ${{ inputs.namespace }}
+      HELMFILE_ENV: ${{ inputs.helmfile_env }}
+      GATEWAY_TYPE: ${{ inputs.gateway_type }}
+      ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}
+      # WVA-specific env vars (only used when deploy_wva is true)
+      MODEL_ID: ${{ inputs.model_id }}
+      WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
+      WVA_NAMESPACE: ${{ format('{0}-system', inputs.namespace) }}
+      WVA_RELEASE_NAME: ${{ format('wva-{0}', inputs.guide_name) }}
     steps:
-      - name: Checkout caller repo
+      - name: Checkout llm-d/llm-d
+        uses: actions/checkout@v6
+        with:
+          repository: llm-d/llm-d
+          ref: ${{ inputs.llm_d_ref || github.ref }}
+
+      - name: Checkout caller repo (WVA)
+        if: inputs.deploy_wva && inputs.caller_repo != ''
         uses: actions/checkout@v6
         with:
           repository: ${{ inputs.caller_repo }}
           ref: ${{ inputs.caller_ref }}
+          path: _caller
 
-      - name: Extract Go version from go.mod
+      - name: Extract Go version from caller repo
+        if: inputs.deploy_wva && inputs.caller_repo != ''
         run: |
-          if [ -f go.mod ]; then
-            sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+          if [ -f _caller/go.mod ]; then
+            sed -En 's/^go (.*)$/GO_VERSION=\1/p' _caller/go.mod >> $GITHUB_ENV
           else
             echo "GO_VERSION=1.23" >> $GITHUB_ENV
           fi
 
       - name: Set up Go
+        if: inputs.deploy_wva && inputs.caller_repo != ''
         uses: actions/setup-go@v6
         with:
           go-version: "${{ env.GO_VERSION }}"
-          cache-dependency-path: ./go.sum
+          cache-dependency-path: _caller/go.sum
 
-      - name: Install tools (kubectl, oc, helm)
+      - name: Install prerequisites (kubectl, helm, helmfile, yq)
         run: |
-          sudo apt-get update && sudo apt-get install -y make
-          # Install kubectl
-          KUBECTL_VERSION="v1.31.0"
-          echo "Installing kubectl version: $KUBECTL_VERSION"
-          curl -fsSL --retry 3 --retry-delay 5 -o kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          curl -fsSL --retry 3 --retry-delay 5 -o kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/
-          rm -f kubectl.sha256
-          # Install oc (OpenShift CLI)
-          curl -fsSL --retry 3 --retry-delay 5 -O "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz"
-          tar -xzf openshift-client-linux.tar.gz
-          sudo mv oc /usr/local/bin/
-          rm -f openshift-client-linux.tar.gz kubectl README.md
-          # Install helm
-          curl -fsSL --retry 3 --retry-delay 5 https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          # Install make (needed by WVA Go tests)
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
+
+          # Install oc (OpenShift CLI) — not included in install-deps.sh
+          if ! command -v oc &>/dev/null; then
+            curl -fsSL --retry 3 --retry-delay 5 -o /tmp/openshift-client-linux.tar.gz \
+              "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz"
+            mkdir -p /tmp/oc-extract
+            tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp/oc-extract
+            sudo mv /tmp/oc-extract/oc /usr/local/bin/
+            rm -rf /tmp/oc-extract /tmp/openshift-client-linux.tar.gz
+          fi
+
+          # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
+          ./helpers/client-setup/install-deps.sh
+
+          # Install jq if not present
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
 
       - name: Verify cluster access
         run: |
-          echo "Verifying cluster access..."
+          echo "Verifying OpenShift cluster access..."
           kubectl cluster-info
           kubectl get nodes
+          oc whoami || true
+
+      - name: Cordon unhealthy GPU nodes
+        run: |
+          echo "Checking for unhealthy GPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r '
+            .items[] | select(
+              ((.status.allocatable["nvidia.com/gpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy GPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All GPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
 
       - name: Check GPU availability
         id: gpu-check
@@ -238,6 +320,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+            # Wait for GPUs if timeout is configured
             if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
               DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
               echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
@@ -254,16 +337,46 @@ jobs:
                 fi
               done
             fi
+            # If still insufficient after waiting, try preemption or fail
             if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
-              WAIT_MSG=""
-              [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+              if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
+                # Count GPU pods with default priority (0) or negative — these can be
+                # preempted by nightly pods deployed with a higher PriorityClass.
+                PREEMPTABLE_GPU_COUNT=$(kubectl get pods --all-namespaces -o json | \
+                  jq '[.items[] | select(
+                    (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber) > 0
+                    and (.spec.priority // 0) <= 0
+                  ) | .spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+                PREEMPTABLE_POD_COUNT=$(kubectl get pods --all-namespaces -o json | \
+                  jq '[.items[] | select(
+                    (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber) > 0
+                    and (.spec.priority // 0) <= 0
+                  )] | length')
+                POTENTIAL_GPUS=$((AVAILABLE_GPUS + PREEMPTABLE_GPU_COUNT))
+                if [ "$POTENTIAL_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient free GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS free. Found $PREEMPTABLE_POD_COUNT preemptable GPU pod(s) holding $PREEMPTABLE_GPU_COUNT GPU(s) — proceeding (Kubernetes will preempt as needed)." >> $GITHUB_STEP_SUMMARY
+                  echo "::warning::Insufficient free GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but $PREEMPTABLE_GPU_COUNT preemptable GPUs available (priority <= 0)"
+                else
+                  WAIT_MSG=""
+                  [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS, have $AVAILABLE_GPUS free + $PREEMPTABLE_GPU_COUNT preemptable = $POTENTIAL_GPUS total (not enough)." >> $GITHUB_STEP_SUMMARY
+                  echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS free + $PREEMPTABLE_GPU_COUNT preemptable = $POTENTIAL_GPUS total.${WAIT_MSG}"
+                  exit 1
+                fi
+              else
+                WAIT_MSG=""
+                [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+                echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
+                exit 1
+              fi
+            else
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
-              echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
-              exit 1
+              echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
             fi
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
           elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY
@@ -292,57 +405,126 @@ jobs:
       - name: Clean up previous nightly resources
         run: |
           echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
-          echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
-          echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
+          echo "  NAMESPACE: $NAMESPACE"
 
-          for ns in "$LLMD_NAMESPACE" "$WVA_NAMESPACE"; do
+          # Build list of namespaces to clean (add WVA namespace if deploying WVA)
+          NAMESPACES="$NAMESPACE"
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
+            NAMESPACES="$NAMESPACE $WVA_NAMESPACE"
+            echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
+          fi
+
+          for ns in $NAMESPACES; do
             if kubectl get namespace "$ns" &>/dev/null; then
-              echo ""
               echo "=== Cleaning up namespace: $ns ==="
-              echo "  Removing HPAs and VAs..."
-              kubectl delete hpa -n "$ns" -l app.kubernetes.io/name=workload-variant-autoscaler --ignore-not-found || true
-              kubectl delete variantautoscaling -n "$ns" -l app.kubernetes.io/name=workload-variant-autoscaler --ignore-not-found || true
+
+              # Destroy helmfile releases if helmfile.yaml.gotmpl exists
+              if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+                echo "  Destroying helmfile releases..."
+                cd "$GUIDE_PATH"
+                helmfile destroy -e "$HELMFILE_ENV" --namespace "$ns" --args --ignore-not-found 2>/dev/null || true
+                cd "$GITHUB_WORKSPACE"
+              fi
+
+              # Fallback: uninstall any remaining helm releases
               for release in $(helm list -n "$ns" -q 2>/dev/null); do
                 echo "  Uninstalling helm release: $release"
                 helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
               done
+
+              # Delete HTTPRoutes and other resources
+              kubectl delete httproute --all -n "$ns" --ignore-not-found || true
+              kubectl delete gateway --all -n "$ns" --ignore-not-found || true
+
+              kubectl delete pods -n "$ns" --all --force --grace-period=0 --wait=false 2>/dev/null || true
               echo "  Deleting namespace: $ns"
-              kubectl delete namespace "$ns" --ignore-not-found --timeout=60s || true
+              kubectl delete namespace "$ns" --ignore-not-found --timeout=120s || \
+                kubectl delete namespace "$ns" --force --grace-period=0 2>/dev/null || true
+              if kubectl get namespace "$ns" 2>/dev/null | grep -q Terminating; then
+                echo "Warning: namespace $ns still Terminating — clearing finalizers"
+                kubectl get namespace "$ns" -o json | \
+                  jq '.spec.finalizers = []' | \
+                  kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
+              fi
             else
               echo "Namespace $ns does not exist, skipping"
             fi
           done
 
           # Clean up cluster-scoped WVA resources from previous nightly
-          echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
-          kubectl delete clusterrole,clusterrolebinding \
-            -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-            --ignore-not-found || true
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
+            kubectl delete clusterrole,clusterrolebinding \
+              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
+              --ignore-not-found || true
 
-          # Clean up orphaned cluster-scoped WVA resources whose owning
-          # namespace no longer exists. These block fresh installs because
-          # Helm refuses to adopt resources owned by a different release.
-          # Only deletes resources whose release-namespace is gone — active
-          # installations are never touched.
-          echo "Cleaning up orphaned cluster-scoped WVA resources..."
-          for kind in clusterrole clusterrolebinding; do
-            kubectl get "$kind" -o json 2>/dev/null | \
-              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-              while IFS=$'\t' read -r name ns; do
-                if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
-                  echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
-                  kubectl delete "$kind" "$name" --ignore-not-found || true
-                fi
-              done
-          done
+            # Clean up orphaned cluster-scoped WVA resources whose owning
+            # namespace no longer exists
+            echo "Cleaning up orphaned cluster-scoped WVA resources..."
+            for kind in clusterrole clusterrolebinding; do
+              kubectl get "$kind" -o json 2>/dev/null | \
+                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+                while IFS=$'\t' read -r name ns; do
+                  if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
+                    echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
+                    kubectl delete "$kind" "$name" --ignore-not-found || true
+                  fi
+                done
+            done
+          fi
 
           echo "Pre-cleanup complete"
 
-      - name: Apply latest CRDs
-        if: inputs.deploy_wva
+      - name: Create nightly PriorityClass
+        if: inputs.allow_gpu_preemption && inputs.required_gpus > 0
         run: |
-          echo "Applying latest VariantAutoscaling CRD..."
-          kubectl apply -f charts/workload-variant-autoscaler/crds/
+          echo "Creating nightly-gpu-critical PriorityClass for GPU preemption..."
+          cat <<'PRIORITY_EOF' | kubectl apply -f -
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          metadata:
+            name: nightly-gpu-critical
+          value: 1000000
+          preemptionPolicy: PreemptLowerPriority
+          globalDefault: false
+          description: "High priority for nightly E2E GPU workloads — preempts default-priority pods"
+          PRIORITY_EOF
+
+      - name: Create namespace and HF token secret
+        run: |
+          echo "Creating namespace $NAMESPACE..."
+          kubectl create namespace "$NAMESPACE" || echo "Namespace already exists"
+
+          echo "Granting \"anyuid\" Security Context Constraint to serviceAccount \"default\" on namespace \"${NAMESPACE}\""
+          oc adm policy add-scc-to-user anyuid -z default -n ${NAMESPACE}
+          echo "Granting \"privileged\" Security Context Constraint to serviceAccount \"default\" on namespace \"${NAMESPACE}\""
+          oc adm policy add-scc-to-user privileged -z default -n ${NAMESPACE}
+
+          echo "Creating HF token secret in $NAMESPACE..."
+          kubectl create secret generic llm-d-hf-token \
+            --from-literal="HF_TOKEN=$HF_TOKEN" \
+            --namespace "$NAMESPACE" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Install gateway provider
+        if: inputs.install_gateway_provider
+        run: |
+          echo "Installing gateway provider dependencies..."
+          cd guides/prereq/gateway-provider
+          ./install-gateway-provider-dependencies.sh
+          helmfile apply -f "${GATEWAY_TYPE}.helmfile.yaml" 2>/dev/null || \
+            helmfile apply -e "${GATEWAY_TYPE}" 2>/dev/null || \
+            echo "::warning::Gateway provider helmfile not found for $GATEWAY_TYPE — may already be installed"
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Wait for gateway control plane
+        if: inputs.install_gateway_provider
+        run: |
+          echo "Waiting for gateway control plane pods..."
+          kubectl wait --for=condition=ready pod \
+            --selector=app.kubernetes.io/managed-by=Helm \
+            --namespace "${GATEWAY_TYPE}-system" \
+            --timeout=300s 2>/dev/null || true
 
       - name: Override vLLM image
         if: inputs.image_override != ''
@@ -350,13 +532,7 @@ jobs:
           set -euo pipefail
           echo "IMAGE_OVERRIDE=${{ inputs.image_override }}" >> $GITHUB_ENV
           echo "Overriding vLLM images to: ${{ inputs.image_override }}"
-          # Pre-clone llm-d so install.sh skips its own clone, then override images
-          if [ ! -d "$LLM_D_PROJECT" ]; then
-            echo "Pre-cloning llm-d at $LLM_D_RELEASE for image override..."
-            git clone -b "$LLM_D_RELEASE" -- "https://github.com/llm-d/llm-d.git" "$LLM_D_PROJECT" &>/dev/null
-          fi
-          GUIDE_PATH="${LLM_D_PROJECT}/guides/$GUIDE_NAME"
-          VALUES_FILES=$(find "$GUIDE_PATH" -name "values*.yaml" 2>/dev/null || true)
+          VALUES_FILES=$(find "$GUIDE_PATH" -name "values*.yaml")
           if [ -z "$VALUES_FILES" ]; then
             echo "::warning::No values*.yaml files found in $GUIDE_PATH — image override will have no effect on values files"
           else
@@ -366,73 +542,116 @@ jobs:
               yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
               yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
               yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-cuda"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              sed -E "s/^#([[:space:]]+)priorityClassName/\1priorityClassName/g" -i $file
             done
           fi
         env:
           IMAGE_OVERRIDE: ${{ inputs.image_override }}
-          LLM_D_PROJECT: llm-d
-          LLM_D_RELEASE: ${{ inputs.llm_d_release }}
 
-      - name: Deploy infrastructure
-        env:
-          ENVIRONMENT: openshift
-          INSTALL_GATEWAY_CTRLPLANE: "false"
-          BENCHMARK_MODE: "false"
-          E2E_TESTS_ENABLED: "true"
-          NAMESPACE_SCOPED: "false"
-          LLMD_NS: ${{ env.LLMD_NAMESPACE }}
-          WVA_NS: ${{ env.WVA_NAMESPACE }}
-          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
-          VLLM_MAX_NUM_SEQS: ${{ inputs.max_num_seqs }}
-          DECODE_REPLICAS: "1"
-          WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
-          # Align helmfile release name postfix with guide name so that
-          # deployment names (ms-<postfix>-llm-d-modelservice-decode) are predictable
-          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
-          # WVA deployment flag — only deploy WVA for workload-autoscaling guide
-          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || 'false' }}
-          DEPLOY_PROMETHEUS: ${{ inputs.deploy_wva && 'true' || 'false' }}
-          DEPLOY_PROMETHEUS_ADAPTER: ${{ inputs.deploy_wva && 'true' || 'false' }}
-          DEPLOY_VA: ${{ inputs.deploy_wva && 'true' || 'false' }}
-          DEPLOY_HPA: ${{ inputs.deploy_wva && 'true' || 'false' }}
-          # OpenShift uses built-in user-workload monitoring, not a separate namespace
-          MONITORING_NAMESPACE: openshift-user-workload-monitoring
-          # Disable bearer token auth on WVA /metrics endpoint — OpenShift's
-          # user-workload-monitoring cannot authenticate with the controller-manager
-          # SA token (Token does not match server's copy). The endpoint is still
-          # only accessible within the cluster network.
-          WVA_METRICS_SECURE: "false"
+      - name: Apply latest WVA CRDs
+        if: inputs.deploy_wva
         run: |
-          echo "Deploying infrastructure for guide: $GUIDE_NAME (nightly)..."
-          echo "  MODEL_ID: $MODEL_ID"
-          echo "  ACCELERATOR_TYPE: $ACCELERATOR_TYPE"
-          echo "  LLMD_NS: $LLMD_NS"
-          echo "  WVA_NS: $WVA_NS"
-          echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
-          echo "  DEPLOY_WVA: $DEPLOY_WVA"
-          echo "  WELL_LIT_PATH_NAME: $WELL_LIT_PATH_NAME"
+          echo "Applying latest VariantAutoscaling CRD..."
+          kubectl apply -f _caller/charts/workload-variant-autoscaler/crds/
 
-          if [ -f ./deploy/install.sh ]; then
-            ./deploy/install.sh --model "$MODEL_ID" --accelerator "$ACCELERATOR_TYPE" --release-name "$WVA_RELEASE_NAME" --environment openshift
-          else
-            echo "::error::deploy/install.sh not found in caller repo"
-            exit 1
-          fi
+      - name: Run pre-deploy script
+        if: inputs.pre_deploy_script != ''
+        run: |
+          echo "Running pre-deploy script..."
+          ${{ inputs.pre_deploy_script }}
 
-      - name: Label namespaces for OpenShift monitoring
+      - name: Label namespace for OpenShift monitoring
         run: |
           echo "Adding openshift.io/user-monitoring label for Prometheus scraping..."
-          kubectl label namespace "$LLMD_NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
-          kubectl label namespace "$WVA_NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
-          echo "Namespace labels applied"
+          kubectl label namespace "$NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
+            kubectl create namespace "$WVA_NAMESPACE" 2>/dev/null || true
+            kubectl label namespace "$WVA_NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
+          fi
+
+      - name: Deploy WVA guide via make
+        if: inputs.deploy_wva
+        env:
+          ENVIRONMENT: openshift
+          LLMD_NS: ${{ inputs.namespace }}
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
+          WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
+          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
+          MONITORING_NAMESPACE: openshift-user-workload-monitoring
+        run: |
+          echo "Deploying WVA controller..."
+          echo "  LLMD_NS: $LLMD_NS"
+          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
+          cd _caller
+          make nightly-deploy-wva-guide
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Deploy guide via helmfile
+        if: inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        run: |
+          echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
+          cd "$GUIDE_PATH"
+          helmfile apply -e "$HELMFILE_ENV" \
+            --namespace "$NAMESPACE" \
+            --skip-schema-validation \
+            ${{ inputs.helmfile_args }} \
+            | tee /tmp/helmfile-deploy.log
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Deploy guide via custom script
+        if: inputs.custom_deploy_script != '' && !inputs.deploy_wva
+        run: |
+          echo "Deploying $GUIDE_NAME via custom script..."
+          ${{ inputs.custom_deploy_script }}
+
+      - name: Deploy HTTPRoute
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        run: |
+          HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
+          if [ -f "$HTTPROUTE" ]; then
+            echo "Deploying HTTPRoute from $HTTPROUTE..."
+            kubectl apply -f "$HTTPROUTE" -n "$NAMESPACE"
+          else
+            echo "::warning::HTTPRoute file $HTTPROUTE not found — skipping"
+          fi
+
+      - name: Show deployment status
+        run: |
+          echo "=== Deployments ==="
+          kubectl get deployments -n "$NAMESPACE" || true
+          echo ""
+          echo "=== StatefulSets ==="
+          kubectl get statefulsets -n "$NAMESPACE" || true
+          echo ""
+          echo "=== LeaderWorkerSets ==="
+          kubectl get leaderworkersets -n "$NAMESPACE" 2>/dev/null || true
+          echo ""
+          echo "=== Pods ==="
+          kubectl get pods -n "$NAMESPACE" -o wide || true
+          echo ""
+          echo "=== Services ==="
+          kubectl get svc -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Helm releases ==="
+          helm list -n "$NAMESPACE" || true
+          echo ""
+          echo "=== InferencePools ==="
+          kubectl get inferencepools -n "$NAMESPACE" || true
+          echo ""
+          echo "=== HTTPRoutes ==="
+          kubectl get httproutes -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Gateways ==="
+          kubectl get gateway -n "$NAMESPACE" || true
 
       # Emit image metadata early so the artifact is available while tests run.
       # Images are fully resolved after override+deploy — no need to wait for tests.
       - name: Emit image metadata
         if: always()
         env:
-          # Legacy WVA-only workflow — WVA is always deployed
-          DEPLOY_WVA: 'true'
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -479,146 +698,156 @@ jobs:
           path: /tmp/image-metadata.json
           retention-days: 90
 
-      - name: Wait for infrastructure to be ready
+      - name: Wait for pods to be ready
+        env:
+          POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
+          POD_READINESS_DELAY: ${{ inputs.pod_readiness_delay }}
         run: |
-          echo "Waiting for deployments to be ready..."
-          kubectl wait --for=condition=available --timeout=300s deployment --all -n "$LLMD_NAMESPACE" || true
-          kubectl get pods -n "$LLMD_NAMESPACE"
-          if kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
+          echo "Waiting for all pods in $NAMESPACE to be ready (timeout: $POD_WAIT_TIMEOUT)..."
+          if ! kubectl wait pod \
+            --for=condition=Ready \
+            --all \
+            -n "$NAMESPACE" \
+            --timeout="$POD_WAIT_TIMEOUT"; then
+            echo "::error::Pods in $NAMESPACE did not become ready within $POD_WAIT_TIMEOUT"
+            echo "--- Pods ---"
+            kubectl get pods -n "$NAMESPACE" -o wide || true
+            echo "--- Describe non-ready pods ---"
+            for pod in $(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "=== Pod: $pod ==="
+              kubectl describe pod "$pod" -n "$NAMESPACE" || true
+              kubectl logs "$pod" -n "$NAMESPACE" --tail=50 || true
+            done
+            exit 1
+          fi
+
+          # Also wait for WVA namespace pods
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
+            echo "Waiting for WVA pods in $WVA_NAMESPACE..."
             kubectl wait --for=condition=available --timeout=300s deployment --all -n "$WVA_NAMESPACE" || true
             kubectl get pods -n "$WVA_NAMESPACE"
           fi
 
-      - name: Verify metrics pipeline
+          if [ "$POD_READINESS_DELAY" -gt 0 ]; then
+            echo "Extra readiness delay: ${POD_READINESS_DELAY}s (model loading)..."
+            sleep "$POD_READINESS_DELAY"
+          fi
+
+          echo "All pods in $NAMESPACE are ready"
+          kubectl get pods -n "$NAMESPACE"
+
+      - name: Wait for gateway to be ready
+        if: inputs.install_gateway_provider
+        run: |
+          GATEWAY_NAME=$(kubectl get gateway -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -n "$GATEWAY_NAME" ]; then
+            echo "Waiting for gateway $GATEWAY_NAME to be programmed..."
+            kubectl wait "gateway/$GATEWAY_NAME" \
+              --for=condition=Programmed=True \
+              -n "$NAMESPACE" \
+              --timeout=300s || echo "::warning::Gateway not programmed within timeout"
+            kubectl get gateway -n "$NAMESPACE"
+          else
+            echo "No gateway resource found in $NAMESPACE — skipping wait"
+          fi
+
+      - name: Verify metrics pipeline (WVA)
         if: inputs.deploy_wva
         env:
           CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
         run: |
           echo "=== Metrics Pipeline Verification ==="
-          echo ""
-
-          # Give the model time to load and start emitting metrics
           echo "Waiting 180s for model to load and metrics to flow..."
           sleep 180
 
-          echo ""
-          echo "--- VariantAutoscaling Status ---"
-          kubectl get variantautoscaling -n "$LLMD_NAMESPACE" -o wide || true
-          echo ""
-          kubectl get variantautoscaling -n "$LLMD_NAMESPACE" -o jsonpath='{range .items[*]}VA: {.metadata.name}{"\n"}  MetricsAvailable: {range .status.conditions[?(@.type=="MetricsAvailable")]}{.status} ({.reason}: {.message}){end}{"\n"}  DesiredOptimizedAlloc: replicas={.status.desiredOptimizedAlloc.numReplicas}, accel={.status.desiredOptimizedAlloc.accelerator}{"\n"}{end}' 2>/dev/null || true
-
-          echo ""
           echo "--- WVA Controller Logs (last 50 lines) ---"
           kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=50 --all-containers 2>/dev/null || echo "Could not retrieve WVA controller logs"
 
-          echo ""
           echo "--- WVA Controller Error Logs ---"
           kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers 2>/dev/null | grep -iE "error|fail|panic|cannot|refused|timeout|unauthorized|forbidden|certificate" | tail -20 || echo "No error logs found"
 
-          echo ""
           echo "--- External Metrics API ---"
           kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.resources[].name' 2>/dev/null || echo "External metrics API not responding"
-          echo ""
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
 
-          echo ""
-          echo "--- Prometheus Adapter Logs (last 30 lines) ---"
-          kubectl logs -n openshift-user-workload-monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=30 2>/dev/null || echo "Could not retrieve Prometheus Adapter logs"
-
-          echo ""
           echo "--- PodMonitors & ServiceMonitors ---"
-          kubectl get podmonitor,servicemonitor -n "$LLMD_NAMESPACE" 2>/dev/null || echo "No monitors found"
+          kubectl get podmonitor,servicemonitor -n "$NAMESPACE" 2>/dev/null || echo "No monitors found"
           kubectl get podmonitor,servicemonitor -n "$CONTROLLER_NAMESPACE" 2>/dev/null || echo "No monitors found in controller namespace"
 
-          echo ""
-          echo "--- vLLM Pod Status ---"
-          kubectl get pods -n "$LLMD_NAMESPACE" -l app.kubernetes.io/component=decode -o wide 2>/dev/null || \
-            kubectl get pods -n "$LLMD_NAMESPACE" | grep -i "model\|decode\|vllm" || echo "No vLLM pods found"
-
-          echo ""
           echo "=== Metrics Pipeline Verification Complete ==="
 
-      - name: Install Go dependencies
+      - name: Install Go dependencies (WVA)
+        if: inputs.deploy_wva && inputs.caller_repo != ''
         run: |
-          if [ -f go.mod ]; then
-            go mod download
-          fi
+          cd _caller
+          go mod download
 
-      - name: Run E2E tests
+      - name: Run WVA E2E validation
+        if: inputs.deploy_wva && inputs.test_target != ''
         env:
           CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
           MONITORING_NAMESPACE: openshift-user-workload-monitoring
-          LLMD_NAMESPACE: ${{ env.LLMD_NAMESPACE }}
+          LLMD_NAMESPACE: ${{ inputs.namespace }}
           GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
           DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
           WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
+          ENVIRONMENT: openshift
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
         run: |
-          echo "Running Nightly E2E tests for $GUIDE_NAME:"
+          echo "Running WVA E2E tests (${{ inputs.test_target }})..."
           echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
           echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
           echo "  DEPLOYMENT: $DEPLOYMENT"
+          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
           echo "  GATEWAY_NAME: $GATEWAY_NAME"
           echo "  MODEL_ID: $MODEL_ID"
-          echo "  REQUEST_RATE: $REQUEST_RATE"
-          echo "  NUM_PROMPTS: $NUM_PROMPTS"
-          echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
+          echo "  ENVIRONMENT: $ENVIRONMENT"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
+          cd _caller
           make ${{ inputs.test_target }}
 
-      - name: Diagnostic dump (on failure)
+      - name: Diagnostic dump (WVA, on failure)
         if: failure() && inputs.deploy_wva
         env:
           CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
         run: |
           echo "=== Post-Failure Diagnostic Dump ==="
 
-          echo ""
-          echo "--- VariantAutoscaling Full Status ---"
-          kubectl describe variantautoscaling -n "$LLMD_NAMESPACE" 2>/dev/null || echo "No VA found"
-
-          echo ""
           echo "--- WVA Controller Logs (full) ---"
           kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers --tail=200 2>/dev/null || echo "Could not retrieve WVA controller logs"
 
-          echo ""
           echo "--- Prometheus Adapter Logs (full) ---"
           kubectl logs -n openshift-user-workload-monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=100 2>/dev/null || echo "Could not retrieve Prometheus Adapter logs"
 
-          echo ""
           echo "--- External Metrics API ---"
           kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.' || echo "External metrics API not responding"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$LLMD_NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas not available"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas not available"
 
-          echo ""
           echo "--- All Pods in Test Namespaces ---"
-          kubectl get pods -n "$LLMD_NAMESPACE" -o wide 2>/dev/null || true
+          kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
           kubectl get pods -n "$CONTROLLER_NAMESPACE" -o wide 2>/dev/null || true
           kubectl get pods -n openshift-user-workload-monitoring 2>/dev/null | grep -E "prometheus-adapter|prometheus-user" || true
 
-          echo ""
-          echo "--- HPA Status ---"
-          kubectl get hpa -n "$LLMD_NAMESPACE" -o wide 2>/dev/null || echo "No HPAs found"
-          kubectl describe hpa -n "$LLMD_NAMESPACE" 2>/dev/null || true
-
-          echo ""
           echo "--- vLLM Pod Logs (last 30 lines) ---"
-          VLLM_POD=$(kubectl get pods -n "$LLMD_NAMESPACE" -o name 2>/dev/null | grep -i "model\|decode" | head -1)
+          VLLM_POD=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep -i "model\|decode" | head -1)
           if [ -n "$VLLM_POD" ]; then
-            kubectl logs -n "$LLMD_NAMESPACE" "$VLLM_POD" --all-containers --tail=30 2>/dev/null || echo "Could not get vLLM logs"
-          else
-            echo "No vLLM pod found"
+            kubectl logs -n "$NAMESPACE" "$VLLM_POD" --all-containers --tail=30 2>/dev/null || echo "Could not get vLLM logs"
           fi
 
-          echo ""
-          echo "--- Namespace Labels ---"
-          kubectl get namespace "$LLMD_NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null | jq '.' || true
-          kubectl get namespace "$CONTROLLER_NAMESPACE" -o jsonpath='{.metadata.labels}' 2>/dev/null | jq '.' || true
-
-          echo ""
           echo "--- WVA ConfigMap (Prometheus config) ---"
           kubectl get configmap -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler -o yaml 2>/dev/null | grep -A5 "PROMETHEUS\|prometheus\|baseURL\|monitoringNamespace" || echo "No WVA ConfigMap found"
 
-          echo ""
           echo "=== Diagnostic Dump Complete ==="
+
+      - name: Run E2E validation
+        if: "!inputs.deploy_wva"
+        env:
+          GATEWAY_HOST: ${{ inputs.gateway_host }}
+        run: |
+          echo "Running E2E validation for $GUIDE_NAME..."
+          cd .github/scripts/e2e
+          ./e2e-validate.sh -n "$NAMESPACE" ${{ inputs.e2e_validate_args }}
 
       - name: Nightly summary
         if: always()
@@ -628,69 +857,127 @@ jobs:
           echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Guide | $GUIDE_NAME |" >> $GITHUB_STEP_SUMMARY
-          echo "| Caller Repo | ${{ inputs.caller_repo }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
+          echo "| Namespace | $NAMESPACE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Helmfile Env | $HELMFILE_ENV |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
           echo "| Accelerator | $ACCELERATOR_TYPE |" >> $GITHUB_STEP_SUMMARY
-          echo "| llm-d Release | $LLM_D_RELEASE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Request Rate | $REQUEST_RATE req/s |" >> $GITHUB_STEP_SUMMARY
-          echo "| Prompts | $NUM_PROMPTS |" >> $GITHUB_STEP_SUMMARY
+          echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            echo "| Caller Repo | ${{ inputs.caller_repo }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
+            echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Collect pod logs
+        if: always()
+        run: |
+          mkdir -p /tmp/pod-logs-$GUIDE_NAME
+          echo "Collecting pod logs from $NAMESPACE..."
+          for pod in $(kubectl get pods -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+            kubectl logs --all-containers=true -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}.log" 2>&1 || true
+            kubectl describe pod -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}-describe.log" 2>&1 || true
+          done
+          # Collect WVA namespace logs too
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
+            echo "Collecting pod logs from $WVA_NAMESPACE..."
+            for pod in $(kubectl get pods -n "$WVA_NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+              kubectl logs --all-containers=true -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}.log" 2>&1 || true
+              kubectl describe pod -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}-describe.log" 2>&1 || true
+            done
+          fi
+          cp /tmp/helmfile-deploy.log "/tmp/pod-logs-$GUIDE_NAME/" 2>/dev/null || true
+
+      - name: Upload pod logs
+        uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: nightly-pod-logs-${{ inputs.guide_name }}
+          path: /tmp/pod-logs-${{ inputs.guide_name }}
+          retention-days: 7
 
       - name: Cleanup infrastructure
         if: always() && inputs.skip_cleanup == false
         run: |
-          echo "Cleaning up ALL nightly test infrastructure..."
-          echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
-          echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
-          echo "  WVA_RELEASE_NAME: $WVA_RELEASE_NAME"
+          echo "Cleaning up nightly test infrastructure for $GUIDE_NAME..."
 
-          # Uninstall WVA helm release
-          helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          # Uninstall WVA helm release first (before namespace deletion)
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          fi
 
-          # Uninstall llm-d helm releases
-          for release in $(helm list -n "$LLMD_NAMESPACE" -q 2>/dev/null); do
-            echo "  Uninstalling release: $release"
-            helm uninstall "$release" -n "$LLMD_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          # Destroy helmfile releases
+          if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+            echo "Destroying helmfile releases..."
+            cd "$GUIDE_PATH"
+            helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" 2>/dev/null || true
+            cd "$GITHUB_WORKSPACE"
+          fi
+
+          # Delete HTTPRoute
+          if [ -n "${{ inputs.httproute_file }}" ] && [ -f "$GUIDE_PATH/${{ inputs.httproute_file }}" ]; then
+            kubectl delete -f "$GUIDE_PATH/${{ inputs.httproute_file }}" -n "$NAMESPACE" --ignore-not-found || true
+          fi
+
+          # Fallback: uninstall remaining helm releases in all namespaces
+          for ns in "$NAMESPACE" ${WVA_NAMESPACE:+"$WVA_NAMESPACE"}; do
+            for release in $(helm list -n "$ns" -q 2>/dev/null); do
+              echo "  Uninstalling release: $release in $ns"
+              helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
+            done
           done
 
           # Delete namespaces — force-delete stuck pods first, then force namespace if graceful times out
-          kubectl delete pods -n "$LLMD_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-          echo "Deleting namespace $LLMD_NAMESPACE..."
-          kubectl delete namespace "$LLMD_NAMESPACE" --ignore-not-found --timeout=120s || \
-            kubectl delete namespace "$LLMD_NAMESPACE" --force --grace-period=0 2>/dev/null || true
-          if kubectl get namespace "$LLMD_NAMESPACE" 2>/dev/null | grep -q Terminating; then
-            echo "Warning: namespace $LLMD_NAMESPACE still Terminating — clearing finalizers"
-            kubectl get namespace "$LLMD_NAMESPACE" -o json | \
+          kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+          echo "Deleting namespace $NAMESPACE..."
+          kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
+            kubectl delete namespace "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          if kubectl get namespace "$NAMESPACE" 2>/dev/null | grep -q Terminating; then
+            echo "Warning: namespace $NAMESPACE still Terminating — clearing finalizers"
+            kubectl get namespace "$NAMESPACE" -o json | \
               jq '.spec.finalizers = []' | \
-              kubectl replace --raw "/api/v1/namespaces/$LLMD_NAMESPACE/finalize" -f - 2>/dev/null || true
+              kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+          fi
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
+            kubectl delete pods -n "$WVA_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+            echo "Deleting namespace $WVA_NAMESPACE..."
+            kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || \
+              kubectl delete namespace "$WVA_NAMESPACE" --force --grace-period=0 2>/dev/null || true
+            if kubectl get namespace "$WVA_NAMESPACE" 2>/dev/null | grep -q Terminating; then
+              echo "Warning: namespace $WVA_NAMESPACE still Terminating — clearing finalizers"
+              kubectl get namespace "$WVA_NAMESPACE" -o json | \
+                jq '.spec.finalizers = []' | \
+                kubectl replace --raw "/api/v1/namespaces/$WVA_NAMESPACE/finalize" -f - 2>/dev/null || true
+            fi
           fi
 
-          kubectl delete pods -n "$WVA_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-          echo "Deleting namespace $WVA_NAMESPACE..."
-          kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || \
-            kubectl delete namespace "$WVA_NAMESPACE" --force --grace-period=0 2>/dev/null || true
-          if kubectl get namespace "$WVA_NAMESPACE" 2>/dev/null | grep -q Terminating; then
-            echo "Warning: namespace $WVA_NAMESPACE still Terminating — clearing finalizers"
-            kubectl get namespace "$WVA_NAMESPACE" -o json | \
-              jq '.spec.finalizers = []' | \
-              kubectl replace --raw "/api/v1/namespaces/$WVA_NAMESPACE/finalize" -f - 2>/dev/null || true
+          # Clean up cluster-scoped WVA resources
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            kubectl delete clusterrole,clusterrolebinding \
+              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
+              --ignore-not-found || true
+
+            # Clean up cluster-scoped resources owned by the nightly namespaces
+            for kind in clusterrole clusterrolebinding; do
+              kubectl get "$kind" -o json 2>/dev/null | \
+                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+                while IFS=$'\t' read -r name ns; do
+                  if [ "$ns" = "$NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                    echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
+                    kubectl delete "$kind" "$name" --ignore-not-found || true
+                  fi
+                done
+            done
           fi
-
-          # Clean up cluster-scoped WVA resources owned by this nightly's release
-          kubectl delete clusterrole,clusterrolebinding \
-            -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-            --ignore-not-found || true
-
-          # Also clean up cluster-scoped resources owned by the nightly namespaces
-          # (covers helmfile-created resources whose instance label differs from WVA_RELEASE_NAME)
-          for kind in clusterrole clusterrolebinding; do
-            kubectl get "$kind" -o json 2>/dev/null | \
-              jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-              while IFS=$'\t' read -r name ns; do
-                if [ "$ns" = "$LLMD_NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
-                  echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
-                  kubectl delete "$kind" "$name" --ignore-not-found || true
-                fi
-              done
-          done
 
           echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi


### PR DESCRIPTION
  **Summary:**

  - Migrate reusable-nightly-e2e-openshift.yaml to support helmfile, kustomize, and custom
  deploy scripts (replaces the old WVA-only workflow with the helmfile workflow as base)
  - Add gateway_host input for explicit endpoint specification (kustomize guides don't deploy
  Gateway resources)
  - Change httproute_file default to '' and install_gateway_provider default to false (opt-in
  instead of assumed)
  - Make gateway readiness wait conditional on install_gateway_provider
  - Inject GATEWAY_HOST env var into e2e-validate.sh step

  Follows the same pattern applied to GKE and CKS in #148.


