### PR TITLE
Add `kustomize` to `Install prerequisites` step in all reusable nightlies

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -233,6 +233,9 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
       - name: Verify cluster access
         run: |
           echo "Verifying CKS cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-gke.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke.yaml
@@ -206,6 +206,9 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
       - name: Verify cluster access
         run: |
           echo "Verifying GKE cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -244,6 +244,9 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
       - name: Verify cluster access
         run: |
           echo "Verifying OpenShift cluster access..."


### PR DESCRIPTION

## What does this PR do?

Add `kustomize` to `Install prerequisites` step in all reusable nightlies

## Why is this change needed?

`kustomize` needs to be explicitly installed on the container image during CI/CD

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
