### PR TITLE
cleanup: remove WVA installation

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -72,18 +72,6 @@ on:
         type: boolean
         default: false
 
-      # --- Model & accelerator ---
-      model_id:
-        description: 'Model ID (empty = auto-discover from guide)'
-        required: false
-        type: string
-        default: ''
-      accelerator_type:
-        description: 'Accelerator type (H100, H200, A100)'
-        required: false
-        type: string
-        default: 'H100'
-
       # --- Deployment configuration ---
       helmfile_args:
         description: 'Extra args passed to helmfile apply (e.g. --set key=val)'
@@ -117,33 +105,6 @@ on:
         default: ''
       image_override:
         description: 'Override vLLM container image (e.g. ghcr.io/llm-d/llm-d-cuda-dev:latest)'
-        required: false
-        type: string
-        default: ''
-
-      # --- WVA integration (optional — enables WVA e2e tests) ---
-      deploy_wva:
-        description: 'Deploy WVA guide via make (enables WVA-specific steps)'
-        required: false
-        type: boolean
-        default: false
-      caller_repo:
-        description: 'Caller repo with deploy/install.sh and Go tests (e.g. llm-d/llm-d-workload-variant-autoscaler)'
-        required: false
-        type: string
-        default: ''
-      caller_ref:
-        description: 'Git ref for caller repo'
-        required: false
-        type: string
-        default: 'main'
-      wva_image_tag:
-        description: 'WVA controller image tag'
-        required: false
-        type: string
-        default: 'v0.5.0'
-      test_target:
-        description: 'Make target for Go tests (e.g. test-e2e) — replaces e2e-validate.sh when set'
         required: false
         type: string
         default: ''
@@ -193,12 +154,6 @@ jobs:
       NAMESPACE: ${{ inputs.namespace }}
       HELMFILE_ENV: ${{ inputs.helmfile_env }}
       GATEWAY_TYPE: ${{ inputs.gateway_type }}
-      ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}
-      # WVA-specific env vars (only used when deploy_wva is true)
-      MODEL_ID: ${{ inputs.model_id }}
-      WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
-      WVA_NAMESPACE: ${{ format('{0}-system', inputs.namespace) }}
-      WVA_RELEASE_NAME: ${{ format('wva-{0}', inputs.guide_name) }}
     steps:
       - name: Checkout llm-d/llm-d
         uses: actions/checkout@v6
@@ -206,37 +161,8 @@ jobs:
           repository: llm-d/llm-d
           ref: ${{ inputs.llm_d_ref || github.ref }}
 
-      - name: Checkout caller repo (WVA)
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.caller_repo }}
-          ref: ${{ inputs.caller_ref }}
-          path: _caller
-
-      - name: Extract Go version from caller repo
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        run: |
-          if [ -f _caller/go.mod ]; then
-            sed -En 's/^go (.*)$/GO_VERSION=\1/p' _caller/go.mod >> $GITHUB_ENV
-          else
-            echo "GO_VERSION=1.23" >> $GITHUB_ENV
-          fi
-
-      - name: Set up Go
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        uses: actions/setup-go@v6
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache-dependency-path: _caller/go.sum
-
       - name: Install prerequisites (kubectl, helm, helmfile, yq)
         run: |
-          # Install make (needed by WVA Go tests)
-          if ! command -v make &>/dev/null; then
-            sudo apt-get update && sudo apt-get install -y make
-          fi
-
           # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
           ./helpers/client-setup/install-deps.sh
 
@@ -410,68 +336,39 @@ jobs:
           echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
           echo "  NAMESPACE: $NAMESPACE"
 
-          # Build list of namespaces to clean (add WVA namespace if deploying WVA)
-          NAMESPACES="$NAMESPACE"
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
-            NAMESPACES="$NAMESPACE $WVA_NAMESPACE"
-            echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
-          fi
+          if kubectl get namespace "$NAMESPACE" &>/dev/null; then
+            echo "=== Cleaning up namespace: $NAMESPACE ==="
 
-          for ns in $NAMESPACES; do
-            if kubectl get namespace "$ns" &>/dev/null; then
-              echo "=== Cleaning up namespace: $ns ==="
-
-              # Destroy helmfile releases if helmfile.yaml.gotmpl exists
-              if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
-                echo "  Destroying helmfile releases..."
-                cd "$GUIDE_PATH"
-                helmfile destroy -e "$HELMFILE_ENV" --namespace "$ns" --args --ignore-not-found 2>/dev/null || true
-                cd "$GITHUB_WORKSPACE"
-              fi
-
-              # Fallback: uninstall any remaining helm releases
-              for release in $(helm list -n "$ns" -q 2>/dev/null); do
-                echo "  Uninstalling helm release: $release"
-                helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
-              done
-
-              # Delete HTTPRoutes and other resources
-              kubectl delete httproute --all -n "$ns" --ignore-not-found || true
-              kubectl delete gateway --all -n "$ns" --ignore-not-found || true
-
-              kubectl delete pods -n "$ns" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-              echo "  Deleting namespace: $ns"
-              kubectl delete namespace "$ns" --ignore-not-found --timeout=120s || \
-                kubectl delete namespace "$ns" --force --grace-period=0 2>/dev/null || true
-              if kubectl get namespace "$ns" 2>/dev/null | grep -q Terminating; then
-                echo "Warning: namespace $ns still Terminating — clearing finalizers"
-                kubectl get namespace "$ns" -o json | \
-                  jq '.spec.finalizers = []' | \
-                  kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
-              fi
-            else
-              echo "Namespace $ns does not exist, skipping"
+            # Destroy helmfile releases if helmfile.yaml.gotmpl exists
+            if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+              echo "  Destroying helmfile releases..."
+              cd "$GUIDE_PATH"
+              helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" --args --ignore-not-found 2>/dev/null || true
+              cd "$GITHUB_WORKSPACE"
             fi
-          done
 
-          # Clean up cluster-scoped WVA resources from previous nightly
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
-            kubectl delete clusterrole,clusterrolebinding \
-              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-              --ignore-not-found || true
-
-            echo "Cleaning up orphaned cluster-scoped WVA resources..."
-            for kind in clusterrole clusterrolebinding; do
-              kubectl get "$kind" -o json 2>/dev/null | \
-                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-                while IFS=$'\t' read -r name ns; do
-                  if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
-                    echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
-                    kubectl delete "$kind" "$name" --ignore-not-found || true
-                  fi
-                done
+            # Fallback: uninstall any remaining helm releases
+            for release in $(helm list -n "$NAMESPACE" -q 2>/dev/null); do
+              echo "  Uninstalling helm release: $release"
+              helm uninstall "$release" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s || true
             done
+
+            # Delete HTTPRoutes and other resources
+            kubectl delete httproute --all -n "$NAMESPACE" --ignore-not-found || true
+            kubectl delete gateway --all -n "$NAMESPACE" --ignore-not-found || true
+
+            kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+            echo "  Deleting namespace: $NAMESPACE"
+            kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
+              kubectl delete namespace "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+            if kubectl get namespace "$NAMESPACE" 2>/dev/null | grep -q Terminating; then
+              echo "Warning: namespace $NAMESPACE still Terminating — clearing finalizers"
+              kubectl get namespace "$NAMESPACE" -o json | \
+                jq '.spec.finalizers = []' | \
+                kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+            fi
+          else
+            echo "Namespace $NAMESPACE does not exist, skipping"
           fi
 
           echo "Pre-cleanup complete"
@@ -544,38 +441,14 @@ jobs:
         env:
           IMAGE_OVERRIDE: ${{ inputs.image_override }}
 
-      - name: Apply latest WVA CRDs
-        if: inputs.deploy_wva
-        run: |
-          echo "Applying latest VariantAutoscaling CRD..."
-          kubectl apply -f _caller/charts/workload-variant-autoscaler/crds/
-
       - name: Run pre-deploy script
         if: inputs.pre_deploy_script != ''
         run: |
           echo "Running pre-deploy script..."
           ${{ inputs.pre_deploy_script }}
 
-      - name: Deploy WVA guide via make
-        if: inputs.deploy_wva
-        env:
-          ENVIRONMENT: kubernetes
-          LLMD_NS: ${{ inputs.namespace }}
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
-          WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
-          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
-        run: |
-          echo "Deploying WVA guide on CKS..."
-          echo "  LLMD_NS: $LLMD_NS"
-          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
-          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
-          cd _caller
-          make nightly-deploy-wva-guide
-          cd "$GITHUB_WORKSPACE"
-
       - name: Deploy guide via helmfile
-        if: inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        if: inputs.custom_deploy_script == ''
         run: |
           echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
           cd "$GUIDE_PATH"
@@ -587,13 +460,13 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
       - name: Deploy guide via custom script
-        if: inputs.custom_deploy_script != '' && !inputs.deploy_wva
+        if: inputs.custom_deploy_script != ''
         run: |
           echo "Deploying $GUIDE_NAME via custom script..."
           ${{ inputs.custom_deploy_script }}
 
       - name: Deploy HTTPRoute
-        if: inputs.httproute_file != '' && inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == ''
         run: |
           HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
           if [ -f "$HTTPROUTE" ]; then
@@ -636,8 +509,6 @@ jobs:
       # Images are fully resolved after override+deploy — no need to wait for tests.
       - name: Emit image metadata
         if: always()
-        env:
-          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -658,15 +529,12 @@ jobs:
           fi
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -712,13 +580,6 @@ jobs:
             sleep "$POD_READINESS_DELAY"
           fi
 
-          # Also wait for WVA namespace pods
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
-            echo "Waiting for WVA pods in $WVA_NAMESPACE..."
-            kubectl wait --for=condition=available --timeout=300s deployment --all -n "$WVA_NAMESPACE" || true
-            kubectl get pods -n "$WVA_NAMESPACE"
-          fi
-
           echo "All pods in $NAMESPACE are ready"
           kubectl get pods -n "$NAMESPACE"
 
@@ -737,77 +598,7 @@ jobs:
             echo "No gateway resource found in $NAMESPACE — skipping wait"
           fi
 
-      - name: Verify metrics pipeline (WVA)
-        if: inputs.deploy_wva
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-        run: |
-          echo "=== Metrics Pipeline Verification ==="
-          echo "Waiting 180s for model to load and metrics to flow..."
-          sleep 180
-
-          echo "--- WVA Controller Logs (last 50 lines) ---"
-          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=50 --all-containers 2>/dev/null || echo "Could not retrieve WVA controller logs"
-
-          echo "--- External Metrics API ---"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.resources[].name' 2>/dev/null || echo "External metrics API not responding"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
-
-          echo "=== Metrics Pipeline Verification Complete ==="
-
-      - name: Install Go dependencies (WVA)
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        run: |
-          cd _caller
-          go mod download
-
-      - name: Run WVA E2E validation
-        if: inputs.deploy_wva && inputs.test_target != ''
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-          LLMD_NAMESPACE: ${{ inputs.namespace }}
-          GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
-          DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
-          WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
-          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
-          ENVIRONMENT: kubernetes
-          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
-        run: |
-          echo "Running WVA E2E validation (${{ inputs.test_target }}) on CKS..."
-          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
-          echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
-          echo "  DEPLOYMENT: $DEPLOYMENT"
-          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
-          echo "  MODEL_ID: $MODEL_ID"
-          echo "  ENVIRONMENT: $ENVIRONMENT"
-          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
-          cd _caller
-          make ${{ inputs.test_target }}
-
-      - name: Diagnostic dump (WVA, on failure)
-        if: failure() && inputs.deploy_wva
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-        run: |
-          echo "=== Post-Failure Diagnostic Dump ==="
-
-          echo "--- VariantAutoscaling Full Status ---"
-          kubectl describe variantautoscaling -n "$NAMESPACE" 2>/dev/null || echo "No VA found"
-
-          echo "--- WVA Controller Logs (full) ---"
-          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers --tail=200 2>/dev/null || echo "Could not retrieve WVA controller logs"
-
-          echo "--- External Metrics API ---"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.' || echo "External metrics API not responding"
-
-          echo "--- All Pods in Test Namespaces ---"
-          kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
-          kubectl get pods -n "$CONTROLLER_NAMESPACE" -o wide 2>/dev/null || true
-
-          echo "=== Diagnostic Dump Complete ==="
-
       - name: Run E2E validation
-        if: "!inputs.deploy_wva"
         env:
           GATEWAY_HOST: ${{ inputs.gateway_host }}
         run: |
@@ -827,13 +618,7 @@ jobs:
           echo "| Namespace | $NAMESPACE |" >> $GITHUB_STEP_SUMMARY
           echo "| Helmfile Env | $HELMFILE_ENV |" >> $GITHUB_STEP_SUMMARY
           echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Accelerator | $ACCELERATOR_TYPE |" >> $GITHUB_STEP_SUMMARY
           echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            echo "| Caller Repo | ${{ inputs.caller_repo }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
-            echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
-          fi
 
       - name: Comment on PR
         if: always() && inputs.pr_number != ''
@@ -883,13 +668,6 @@ jobs:
             kubectl logs --all-containers=true -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}.log" 2>&1 || true
             kubectl describe pod -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}-describe.log" 2>&1 || true
           done
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
-            echo "Collecting pod logs from $WVA_NAMESPACE..."
-            for pod in $(kubectl get pods -n "$WVA_NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
-              kubectl logs --all-containers=true -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}.log" 2>&1 || true
-              kubectl describe pod -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}-describe.log" 2>&1 || true
-            done
-          fi
           cp /tmp/helmfile-deploy.log "/tmp/pod-logs-$GUIDE_NAME/" 2>/dev/null || true
 
       - name: Upload pod logs
@@ -905,11 +683,6 @@ jobs:
         run: |
           echo "Cleaning up nightly test infrastructure for $GUIDE_NAME..."
 
-          # Uninstall WVA helm release first
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
-          fi
-
           # Destroy helmfile releases
           if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
             echo "Destroying helmfile releases..."
@@ -923,15 +696,13 @@ jobs:
             kubectl delete -f "$GUIDE_PATH/${{ inputs.httproute_file }}" -n "$NAMESPACE" --ignore-not-found || true
           fi
 
-          # Fallback: uninstall remaining helm releases in all namespaces
-          for ns in "$NAMESPACE" ${WVA_NAMESPACE:+"$WVA_NAMESPACE"}; do
-            for release in $(helm list -n "$ns" -q 2>/dev/null); do
-              echo "  Uninstalling release: $release in $ns"
-              helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
-            done
+          # Fallback: uninstall remaining helm releases
+          for release in $(helm list -n "$NAMESPACE" -q 2>/dev/null); do
+            echo "  Uninstalling release: $release in $NAMESPACE"
+            helm uninstall "$release" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s || true
           done
 
-          # Delete namespaces — force-delete stuck pods first, then force namespace if graceful times out
+          # Delete namespace — force-delete stuck pods first, then force namespace if graceful times out
           kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
           echo "Deleting namespace $NAMESPACE..."
           kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
@@ -941,47 +712,6 @@ jobs:
             kubectl get namespace "$NAMESPACE" -o json | \
               jq '.spec.finalizers = []' | \
               kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
-          fi
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
-            kubectl delete pods -n "$WVA_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-            echo "Deleting namespace $WVA_NAMESPACE..."
-            kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || \
-              kubectl delete namespace "$WVA_NAMESPACE" --force --grace-period=0 2>/dev/null || true
-            if kubectl get namespace "$WVA_NAMESPACE" 2>/dev/null | grep -q Terminating; then
-              echo "Warning: namespace $WVA_NAMESPACE still Terminating — clearing finalizers"
-              kubectl get namespace "$WVA_NAMESPACE" -o json | \
-                jq '.spec.finalizers = []' | \
-                kubectl replace --raw "/api/v1/namespaces/$WVA_NAMESPACE/finalize" -f - 2>/dev/null || true
-            fi
-          fi
-          # WVA install.sh creates a monitoring namespace for kube-prometheus-stack.
-          # Clean it up to prevent stale DaemonSet pods from blocking future runs.
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            MONITORING_NS="workload-variant-autoscaler-monitoring"
-            if kubectl get namespace "$MONITORING_NS" &>/dev/null; then
-              echo "Cleaning up WVA monitoring namespace $MONITORING_NS..."
-              helm uninstall kube-prometheus-stack -n "$MONITORING_NS" --ignore-not-found 2>/dev/null || true
-              helm uninstall prometheus-adapter -n "$MONITORING_NS" --ignore-not-found 2>/dev/null || true
-              kubectl delete namespace "$MONITORING_NS" --ignore-not-found --timeout=120s || true
-            fi
-          fi
-
-          # Clean up cluster-scoped WVA resources
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            kubectl delete clusterrole,clusterrolebinding \
-              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-              --ignore-not-found || true
-
-            for kind in clusterrole clusterrolebinding; do
-              kubectl get "$kind" -o json 2>/dev/null | \
-                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-                while IFS=$'\t' read -r name ns; do
-                  if [ "$ns" = "$NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
-                    echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
-                    kubectl delete "$kind" "$name" --ignore-not-found || true
-                  fi
-                done
-            done
           fi
 
           echo "Nightly cleanup complete"

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -73,18 +73,6 @@ on:
         type: boolean
         default: false
 
-      # --- Model & accelerator ---
-      model_id:
-        description: 'Model ID (empty = auto-discover from guide)'
-        required: false
-        type: string
-        default: ''
-      accelerator_type:
-        description: 'Accelerator type (H100, A100, L40S)'
-        required: false
-        type: string
-        default: 'A100'
-
       # --- Deployment configuration ---
       helmfile_args:
         description: 'Extra args passed to helmfile apply (e.g. --set key=val)'
@@ -122,22 +110,7 @@ on:
         type: string
         default: ''
 
-      # --- WVA integration (optional — enables WVA e2e tests) ---
-      deploy_wva:
-        description: 'Deploy WVA guide via make (enables WVA-specific steps)'
-        required: false
-        type: boolean
-        default: false
-      caller_repo:
-        description: 'Caller repo with deploy/install.sh and Go tests (e.g. llm-d/llm-d-workload-variant-autoscaler)'
-        required: false
-        type: string
-        default: ''
-      caller_ref:
-        description: 'Git ref for caller repo'
-        required: false
-        type: string
-        default: 'main'
+      # --- WVA integration (optional ) ---
       wva_image_tag:
         description: 'WVA controller image tag'
         required: false
@@ -194,12 +167,8 @@ jobs:
       NAMESPACE: ${{ inputs.namespace }}
       HELMFILE_ENV: ${{ inputs.helmfile_env }}
       GATEWAY_TYPE: ${{ inputs.gateway_type }}
-      ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}
-      # WVA-specific env vars (only used when deploy_wva is true)
-      MODEL_ID: ${{ inputs.model_id }}
+      # WVA-specific env vars
       WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
-      WVA_NAMESPACE: ${{ format('{0}-system', inputs.namespace) }}
-      WVA_RELEASE_NAME: ${{ format('wva-{0}', inputs.guide_name) }}
     steps:
       - name: Checkout llm-d/llm-d
         uses: actions/checkout@v6
@@ -207,37 +176,8 @@ jobs:
           repository: llm-d/llm-d
           ref: ${{ inputs.llm_d_ref || github.ref }}
 
-      - name: Checkout caller repo (WVA)
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ inputs.caller_repo }}
-          ref: ${{ inputs.caller_ref }}
-          path: _caller
-
-      - name: Extract Go version from caller repo
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        run: |
-          if [ -f _caller/go.mod ]; then
-            sed -En 's/^go (.*)$/GO_VERSION=\1/p' _caller/go.mod >> $GITHUB_ENV
-          else
-            echo "GO_VERSION=1.23" >> $GITHUB_ENV
-          fi
-
-      - name: Set up Go
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        uses: actions/setup-go@v6
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache-dependency-path: _caller/go.sum
-
       - name: Install prerequisites (kubectl, helm, helmfile, yq)
         run: |
-          # Install make (needed by WVA Go tests)
-          if ! command -v make &>/dev/null; then
-            sudo apt-get update && sudo apt-get install -y make
-          fi
-
           # Install oc (OpenShift CLI) — not included in install-deps.sh
           if ! command -v oc &>/dev/null; then
             curl -fsSL --retry 3 --retry-delay 5 -o /tmp/openshift-client-linux.tar.gz \
@@ -424,10 +364,6 @@ jobs:
 
           # Build list of namespaces to clean (add WVA namespace if deploying WVA)
           NAMESPACES="$NAMESPACE"
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
-            NAMESPACES="$NAMESPACE $WVA_NAMESPACE"
-            echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
-          fi
 
           for ns in $NAMESPACES; do
             if kubectl get namespace "$ns" &>/dev/null; then
@@ -465,28 +401,6 @@ jobs:
               echo "Namespace $ns does not exist, skipping"
             fi
           done
-
-          # Clean up cluster-scoped WVA resources from previous nightly
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
-            kubectl delete clusterrole,clusterrolebinding \
-              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-              --ignore-not-found || true
-
-            # Clean up orphaned cluster-scoped WVA resources whose owning
-            # namespace no longer exists
-            echo "Cleaning up orphaned cluster-scoped WVA resources..."
-            for kind in clusterrole clusterrolebinding; do
-              kubectl get "$kind" -o json 2>/dev/null | \
-                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-                while IFS=$'\t' read -r name ns; do
-                  if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
-                    echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
-                    kubectl delete "$kind" "$name" --ignore-not-found || true
-                  fi
-                done
-            done
-          fi
 
           echo "Pre-cleanup complete"
 
@@ -563,12 +477,6 @@ jobs:
         env:
           IMAGE_OVERRIDE: ${{ inputs.image_override }}
 
-      - name: Apply latest WVA CRDs
-        if: inputs.deploy_wva
-        run: |
-          echo "Applying latest VariantAutoscaling CRD..."
-          kubectl apply -f _caller/charts/workload-variant-autoscaler/crds/
-
       - name: Run pre-deploy script
         if: inputs.pre_deploy_script != ''
         run: |
@@ -579,32 +487,9 @@ jobs:
         run: |
           echo "Adding openshift.io/user-monitoring label for Prometheus scraping..."
           kubectl label namespace "$NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
-            kubectl create namespace "$WVA_NAMESPACE" 2>/dev/null || true
-            kubectl label namespace "$WVA_NAMESPACE" openshift.io/user-monitoring=true --overwrite || true
-          fi
-
-      - name: Deploy WVA guide via make
-        if: inputs.deploy_wva
-        env:
-          ENVIRONMENT: openshift
-          LLMD_NS: ${{ inputs.namespace }}
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
-          WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
-          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
-          MONITORING_NAMESPACE: openshift-user-workload-monitoring
-        run: |
-          echo "Deploying WVA controller..."
-          echo "  LLMD_NS: $LLMD_NS"
-          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
-          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
-          cd _caller
-          make nightly-deploy-wva-guide
-          cd "$GITHUB_WORKSPACE"
 
       - name: Deploy guide via helmfile
-        if: inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        if: inputs.custom_deploy_script == ''
         run: |
           echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
           cd "$GUIDE_PATH"
@@ -616,13 +501,13 @@ jobs:
           cd "$GITHUB_WORKSPACE"
 
       - name: Deploy guide via custom script
-        if: inputs.custom_deploy_script != '' && !inputs.deploy_wva
+        if: inputs.custom_deploy_script != ''
         run: |
           echo "Deploying $GUIDE_NAME via custom script..."
           ${{ inputs.custom_deploy_script }}
 
       - name: Deploy HTTPRoute
-        if: inputs.httproute_file != '' && inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == ''
         run: |
           HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
           if [ -f "$HTTPROUTE" ]; then
@@ -665,8 +550,6 @@ jobs:
       # Images are fully resolved after override+deploy — no need to wait for tests.
       - name: Emit image metadata
         if: always()
-        env:
-          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
         run: |
           set -euo pipefail
           METADATA_FILE=/tmp/image-metadata.json
@@ -688,14 +571,13 @@ jobs:
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
             --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
-            --arg deployWva "${DEPLOY_WVA:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"
@@ -736,13 +618,6 @@ jobs:
             exit 1
           fi
 
-          # Also wait for WVA namespace pods
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
-            echo "Waiting for WVA pods in $WVA_NAMESPACE..."
-            kubectl wait --for=condition=available --timeout=300s deployment --all -n "$WVA_NAMESPACE" || true
-            kubectl get pods -n "$WVA_NAMESPACE"
-          fi
-
           if [ "$POD_READINESS_DELAY" -gt 0 ]; then
             echo "Extra readiness delay: ${POD_READINESS_DELAY}s (model loading)..."
             sleep "$POD_READINESS_DELAY"
@@ -766,97 +641,7 @@ jobs:
             echo "No gateway resource found in $NAMESPACE — skipping wait"
           fi
 
-      - name: Verify metrics pipeline (WVA)
-        if: inputs.deploy_wva
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-        run: |
-          echo "=== Metrics Pipeline Verification ==="
-          echo "Waiting 180s for model to load and metrics to flow..."
-          sleep 180
-
-          echo "--- WVA Controller Logs (last 50 lines) ---"
-          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=50 --all-containers 2>/dev/null || echo "Could not retrieve WVA controller logs"
-
-          echo "--- WVA Controller Error Logs ---"
-          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers 2>/dev/null | grep -iE "error|fail|panic|cannot|refused|timeout|unauthorized|forbidden|certificate" | tail -20 || echo "No error logs found"
-
-          echo "--- External Metrics API ---"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.resources[].name' 2>/dev/null || echo "External metrics API not responding"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
-
-          echo "--- PodMonitors & ServiceMonitors ---"
-          kubectl get podmonitor,servicemonitor -n "$NAMESPACE" 2>/dev/null || echo "No monitors found"
-          kubectl get podmonitor,servicemonitor -n "$CONTROLLER_NAMESPACE" 2>/dev/null || echo "No monitors found in controller namespace"
-
-          echo "=== Metrics Pipeline Verification Complete ==="
-
-      - name: Install Go dependencies (WVA)
-        if: inputs.deploy_wva && inputs.caller_repo != ''
-        run: |
-          cd _caller
-          go mod download
-
-      - name: Run WVA E2E validation
-        if: inputs.deploy_wva && inputs.test_target != ''
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-          MONITORING_NAMESPACE: openshift-user-workload-monitoring
-          LLMD_NAMESPACE: ${{ inputs.namespace }}
-          GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
-          DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
-          WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
-          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
-          ENVIRONMENT: openshift
-          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
-        run: |
-          echo "Running WVA E2E tests (${{ inputs.test_target }})..."
-          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
-          echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
-          echo "  DEPLOYMENT: $DEPLOYMENT"
-          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
-          echo "  GATEWAY_NAME: $GATEWAY_NAME"
-          echo "  MODEL_ID: $MODEL_ID"
-          echo "  ENVIRONMENT: $ENVIRONMENT"
-          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
-          cd _caller
-          make ${{ inputs.test_target }}
-
-      - name: Diagnostic dump (WVA, on failure)
-        if: failure() && inputs.deploy_wva
-        env:
-          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
-        run: |
-          echo "=== Post-Failure Diagnostic Dump ==="
-
-          echo "--- WVA Controller Logs (full) ---"
-          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers --tail=200 2>/dev/null || echo "Could not retrieve WVA controller logs"
-
-          echo "--- Prometheus Adapter Logs (full) ---"
-          kubectl logs -n openshift-user-workload-monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=100 2>/dev/null || echo "Could not retrieve Prometheus Adapter logs"
-
-          echo "--- External Metrics API ---"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.' || echo "External metrics API not responding"
-          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas not available"
-
-          echo "--- All Pods in Test Namespaces ---"
-          kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
-          kubectl get pods -n "$CONTROLLER_NAMESPACE" -o wide 2>/dev/null || true
-          kubectl get pods -n openshift-user-workload-monitoring 2>/dev/null | grep -E "prometheus-adapter|prometheus-user" || true
-
-          echo "--- vLLM Pod Logs (last 30 lines) ---"
-          VLLM_POD=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep -i "model\|decode" | head -1)
-          if [ -n "$VLLM_POD" ]; then
-            kubectl logs -n "$NAMESPACE" "$VLLM_POD" --all-containers --tail=30 2>/dev/null || echo "Could not get vLLM logs"
-          fi
-
-          echo "--- WVA ConfigMap (Prometheus config) ---"
-          kubectl get configmap -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler -o yaml 2>/dev/null | grep -A5 "PROMETHEUS\|prometheus\|baseURL\|monitoringNamespace" || echo "No WVA ConfigMap found"
-
-          echo "=== Diagnostic Dump Complete ==="
-
       - name: Run E2E validation
-        if: "!inputs.deploy_wva"
         env:
           GATEWAY_HOST: ${{ inputs.gateway_host }}
         run: |
@@ -875,13 +660,7 @@ jobs:
           echo "| Namespace | $NAMESPACE |" >> $GITHUB_STEP_SUMMARY
           echo "| Helmfile Env | $HELMFILE_ENV |" >> $GITHUB_STEP_SUMMARY
           echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Accelerator | $ACCELERATOR_TYPE |" >> $GITHUB_STEP_SUMMARY
           echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            echo "| Caller Repo | ${{ inputs.caller_repo }} |" >> $GITHUB_STEP_SUMMARY
-            echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
-            echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
-          fi
 
       - name: Comment on PR
         if: always() && inputs.pr_number != ''
@@ -931,14 +710,6 @@ jobs:
             kubectl logs --all-containers=true -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}.log" 2>&1 || true
             kubectl describe pod -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}-describe.log" 2>&1 || true
           done
-          # Collect WVA namespace logs too
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
-            echo "Collecting pod logs from $WVA_NAMESPACE..."
-            for pod in $(kubectl get pods -n "$WVA_NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
-              kubectl logs --all-containers=true -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}.log" 2>&1 || true
-              kubectl describe pod -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}-describe.log" 2>&1 || true
-            done
-          fi
           cp /tmp/helmfile-deploy.log "/tmp/pod-logs-$GUIDE_NAME/" 2>/dev/null || true
 
       - name: Upload pod logs
@@ -954,11 +725,6 @@ jobs:
         run: |
           echo "Cleaning up nightly test infrastructure for $GUIDE_NAME..."
 
-          # Uninstall WVA helm release first (before namespace deletion)
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
-          fi
-
           # Destroy helmfile releases
           if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
             echo "Destroying helmfile releases..."
@@ -973,7 +739,7 @@ jobs:
           fi
 
           # Fallback: uninstall remaining helm releases in all namespaces
-          for ns in "$NAMESPACE" ${WVA_NAMESPACE:+"$WVA_NAMESPACE"}; do
+          for ns in "$NAMESPACE" do
             for release in $(helm list -n "$ns" -q 2>/dev/null); do
               echo "  Uninstalling release: $release in $ns"
               helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
@@ -990,37 +756,6 @@ jobs:
             kubectl get namespace "$NAMESPACE" -o json | \
               jq '.spec.finalizers = []' | \
               kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
-          fi
-          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
-            kubectl delete pods -n "$WVA_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-            echo "Deleting namespace $WVA_NAMESPACE..."
-            kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || \
-              kubectl delete namespace "$WVA_NAMESPACE" --force --grace-period=0 2>/dev/null || true
-            if kubectl get namespace "$WVA_NAMESPACE" 2>/dev/null | grep -q Terminating; then
-              echo "Warning: namespace $WVA_NAMESPACE still Terminating — clearing finalizers"
-              kubectl get namespace "$WVA_NAMESPACE" -o json | \
-                jq '.spec.finalizers = []' | \
-                kubectl replace --raw "/api/v1/namespaces/$WVA_NAMESPACE/finalize" -f - 2>/dev/null || true
-            fi
-          fi
-
-          # Clean up cluster-scoped WVA resources
-          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
-            kubectl delete clusterrole,clusterrolebinding \
-              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
-              --ignore-not-found || true
-
-            # Clean up cluster-scoped resources owned by the nightly namespaces
-            for kind in clusterrole clusterrolebinding; do
-              kubectl get "$kind" -o json 2>/dev/null | \
-                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
-                while IFS=$'\t' read -r name ns; do
-                  if [ "$ns" = "$NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
-                    echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
-                    kubectl delete "$kind" "$name" --ignore-not-found || true
-                  fi
-                done
-            done
           fi
 
           echo "Nightly cleanup complete"

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -109,13 +109,6 @@ on:
         required: false
         type: string
         default: ''
-
-      # --- WVA integration (optional ) ---
-      wva_image_tag:
-        description: 'WVA controller image tag'
-        required: false
-        type: string
-        default: 'v0.5.0'
       test_target:
         description: 'Make target for Go tests (e.g. test-e2e-openshift) — replaces e2e-validate.sh when set'
         required: false
@@ -167,8 +160,6 @@ jobs:
       NAMESPACE: ${{ inputs.namespace }}
       HELMFILE_ENV: ${{ inputs.helmfile_env }}
       GATEWAY_TYPE: ${{ inputs.gateway_type }}
-      # WVA-specific env vars
-      WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
     steps:
       - name: Checkout llm-d/llm-d
         uses: actions/checkout@v6
@@ -362,7 +353,7 @@ jobs:
           echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
           echo "  NAMESPACE: $NAMESPACE"
 
-          # Build list of namespaces to clean (add WVA namespace if deploying WVA)
+          # Build list of namespaces to clean
           NAMESPACES="$NAMESPACE"
 
           for ns in $NAMESPACES; do
@@ -570,14 +561,12 @@ jobs:
           fi
           jq -n \
             --arg imageOverride "${IMAGE_OVERRIDE:-}" \
-            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
             --arg guideName "$GUIDE_NAME" \
             --argjson llmdImages "$LLMD_IMAGES" \
             --argjson otherImages "$OTHER_IMAGES" \
             '{
               guideName: $guideName,
               imageOverride: (if $imageOverride != "" then $imageOverride else null end),
-              wvaImageTag: (if $wvaImageTag != "" then $wvaImageTag else null end),
               llmdImages: $llmdImages,
               otherImages: $otherImages
             }' > "$METADATA_FILE"

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -109,11 +109,6 @@ on:
         required: false
         type: string
         default: ''
-      test_target:
-        description: 'Make target for Go tests (e.g. test-e2e-openshift) — replaces e2e-validate.sh when set'
-        required: false
-        type: string
-        default: ''
 
       # --- Test configuration ---
       e2e_validate_args:
@@ -353,45 +348,40 @@ jobs:
           echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
           echo "  NAMESPACE: $NAMESPACE"
 
-          # Build list of namespaces to clean
-          NAMESPACES="$NAMESPACE"
+          if kubectl get namespace "$ns" &>/dev/null; then
+            echo "=== Cleaning up namespace: $ns ==="
 
-          for ns in $NAMESPACES; do
-            if kubectl get namespace "$ns" &>/dev/null; then
-              echo "=== Cleaning up namespace: $ns ==="
-
-              # Destroy helmfile releases if helmfile.yaml.gotmpl exists
-              if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
-                echo "  Destroying helmfile releases..."
-                cd "$GUIDE_PATH"
-                helmfile destroy -e "$HELMFILE_ENV" --namespace "$ns" --args --ignore-not-found 2>/dev/null || true
-                cd "$GITHUB_WORKSPACE"
-              fi
-
-              # Fallback: uninstall any remaining helm releases
-              for release in $(helm list -n "$ns" -q 2>/dev/null); do
-                echo "  Uninstalling helm release: $release"
-                helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
-              done
-
-              # Delete HTTPRoutes and other resources
-              kubectl delete httproute --all -n "$ns" --ignore-not-found || true
-              kubectl delete gateway --all -n "$ns" --ignore-not-found || true
-
-              kubectl delete pods -n "$ns" --all --force --grace-period=0 --wait=false 2>/dev/null || true
-              echo "  Deleting namespace: $ns"
-              kubectl delete namespace "$ns" --ignore-not-found --timeout=120s || \
-                kubectl delete namespace "$ns" --force --grace-period=0 2>/dev/null || true
-              if kubectl get namespace "$ns" 2>/dev/null | grep -q Terminating; then
-                echo "Warning: namespace $ns still Terminating — clearing finalizers"
-                kubectl get namespace "$ns" -o json | \
-                  jq '.spec.finalizers = []' | \
-                  kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
-              fi
-            else
-              echo "Namespace $ns does not exist, skipping"
+            # Destroy helmfile releases if helmfile.yaml.gotmpl exists
+            if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+              echo "  Destroying helmfile releases..."
+              cd "$GUIDE_PATH"
+              helmfile destroy -e "$HELMFILE_ENV" --namespace "$ns" --args --ignore-not-found 2>/dev/null || true
+              cd "$GITHUB_WORKSPACE"
             fi
-          done
+
+            # Fallback: uninstall any remaining helm releases
+            for release in $(helm list -n "$ns" -q 2>/dev/null); do
+              echo "  Uninstalling helm release: $release"
+              helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
+            done
+
+            # Delete HTTPRoutes and other resources
+            kubectl delete httproute --all -n "$ns" --ignore-not-found || true
+            kubectl delete gateway --all -n "$ns" --ignore-not-found || true
+
+            kubectl delete pods -n "$ns" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+            echo "  Deleting namespace: $ns"
+            kubectl delete namespace "$ns" --ignore-not-found --timeout=120s || \
+              kubectl delete namespace "$ns" --force --grace-period=0 2>/dev/null || true
+            if kubectl get namespace "$ns" 2>/dev/null | grep -q Terminating; then
+              echo "Warning: namespace $ns still Terminating — clearing finalizers"
+              kubectl get namespace "$ns" -o json | \
+                jq '.spec.finalizers = []' | \
+                kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
+            fi
+          else
+            echo "Namespace $ns does not exist, skipping"
+          fi
 
           echo "Pre-cleanup complete"
 
@@ -728,7 +718,7 @@ jobs:
           fi
 
           # Fallback: uninstall remaining helm releases in all namespaces
-          for ns in "$NAMESPACE" do
+          for ns in "$NAMESPACE"; do
             for release in $(helm list -n "$ns" -q 2>/dev/null); do
               echo "  Uninstalling release: $release in $ns"
               helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true


### PR DESCRIPTION
## What does this PR do?

remove WVA installation

## Why is this change needed?

not needed anymore as the installation is already done in the WVA nightly workflow (https://github.com/llm-d/llm-d/blob/main/.github/workflows/nightly-e2e-wva-ocp.yaml#L72)

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
