### PR TITLE
fix: added timeout-minutes: 90 to reusable nightly workflows

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -186,6 +186,7 @@ on:
 
 jobs:
   nightly-e2e:
+    timeout-minutes: 90
     runs-on: [self-hosted, linux, waldorf]
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}

--- a/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
@@ -186,6 +186,7 @@ on:
 
 jobs:
   nightly-e2e-tpu:
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}

--- a/.github/workflows/reusable-nightly-e2e-gke.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke.yaml
@@ -171,6 +171,7 @@ on:
 
 jobs:
   nightly-e2e:
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -169,6 +169,7 @@ on:
 
 jobs:
   nightly-e2e:
+    timeout-minutes: 90
     runs-on: [self-hosted, openshift, pok-prod]
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -187,6 +187,7 @@ on:
 
 jobs:
   nightly-e2e:
+    timeout-minutes: 90
     runs-on: [self-hosted, openshift, pok-prod]
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}

--- a/.github/workflows/reusable-nightly-e2e-xpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-xpu.yaml
@@ -101,6 +101,7 @@ on:
 
 jobs:
   nightly-e2e:
+    timeout-minutes: 90
     runs-on: xpu
     env:
       GUIDE_NAME: ${{ inputs.guide_name }}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->
add timeout for 90min for the nightly job

## Why is this change needed?
to fix https://github.com/llm-d/llm-d/actions/runs/26084815193/job/76695097393 
originally the changes was add in https://github.com/llm-d/llm-d/pull/1575 but since workflow has reuse template, cannot work  reverted in https://github.com/llm-d/llm-d/pull/1583


<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
