### PR TITLE
add pr_number/pr_repo inputs to OCP helmfile reusable workflow

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
@@ -13,7 +13,7 @@ name: Reusable - Nightly E2E GKE TPU (Helmfile)
 #         guide_name: optimized-baseline
 #         namespace: llm-d-nightly-tpu-baseline
 #         helmfile_env: gke_tpu
-#         tpu_type: v5e-8
+#         tpu_type: v6e-8
 #       secrets: inherit
 #
 #     nightly-tpu-pd:
@@ -22,7 +22,7 @@ name: Reusable - Nightly E2E GKE TPU (Helmfile)
 #         guide_name: pd-disaggregation
 #         namespace: llm-d-nightly-tpu-pd
 #         helmfile_env: gke_tpu
-#         tpu_type: v5e-8
+#         tpu_type: v6e-8
 #         required_tpu_chips: 16
 #       secrets: inherit
 #
@@ -32,7 +32,7 @@ name: Reusable - Nightly E2E GKE TPU (Helmfile)
 #         guide_name: tiered-prefix-cache
 #         namespace: llm-d-nightly-tpu-tpc
 #         helmfile_env: gke_tpu
-#         tpu_type: v5e-8
+#         tpu_type: v6e-8
 #       secrets: inherit
 
 on:
@@ -80,7 +80,7 @@ on:
         description: 'GKE cluster name'
         required: false
         type: string
-        default: 'llm-d-e2e-tpu'
+        default: 'llm-d-e2e-us-east5'
       gke_cluster_zone:
         description: 'GKE cluster zone'
         required: false
@@ -89,10 +89,10 @@ on:
 
       # --- TPU requirements ---
       tpu_type:
-        description: 'TPU chip type (e.g. v5e-8, v4-8, v5p-8)'
+        description: 'TPU chip type (e.g. v6e-8, v4-8, v5p-8)'
         required: false
         type: string
-        default: 'v5e-8'
+        default: 'v6e-8'
       required_tpu_chips:
         description: 'Minimum TPU chip count required (0 for simulated)'
         required: false

--- a/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
@@ -1,0 +1,721 @@
+name: Reusable - Nightly E2E GKE TPU (Helmfile)
+
+# Reusable workflow for nightly e2e testing of helmfile-based llm-d guides
+# on GKE with TPU accelerators. Called by the llm-d/llm-d repo to deploy
+# a guide's stack via helmfile and run the e2e-validate.sh smoke-test suite.
+#
+# Usage from a caller workflow:
+#
+#   jobs:
+#     nightly-tpu-optimized-baseline:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+#       with:
+#         guide_name: optimized-baseline
+#         namespace: llm-d-nightly-tpu-baseline
+#         helmfile_env: gke_tpu
+#         tpu_type: v5e-8
+#       secrets: inherit
+#
+#     nightly-tpu-pd:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+#       with:
+#         guide_name: pd-disaggregation
+#         namespace: llm-d-nightly-tpu-pd
+#         helmfile_env: gke_tpu
+#         tpu_type: v5e-8
+#         required_tpu_chips: 16
+#       secrets: inherit
+#
+#     nightly-tpu-tiered-prefix-cache:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+#       with:
+#         guide_name: tiered-prefix-cache
+#         namespace: llm-d-nightly-tpu-tpc
+#         helmfile_env: gke_tpu
+#         tpu_type: v5e-8
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      # --- Guide configuration ---
+      guide_name:
+        description: 'Guide directory name under guides/ in llm-d/llm-d'
+        required: true
+        type: string
+      guide_path:
+        description: 'Override path to guide directory (default: guides/<guide_name>)'
+        required: false
+        type: string
+        default: ''
+      namespace:
+        description: 'Kubernetes namespace for the deployment'
+        required: true
+        type: string
+      helmfile_env:
+        description: 'Helmfile environment (gke_tpu, etc.)'
+        required: false
+        type: string
+        default: 'gke_tpu'
+      gateway_type:
+        description: 'Gateway provider type (gke, istio, kgateway)'
+        required: false
+        type: string
+        default: 'gke'
+
+      # --- Repository ---
+      llm_d_ref:
+        description: 'Git ref for llm-d/llm-d checkout (default: main)'
+        required: false
+        type: string
+        default: ''
+
+      # --- GKE cluster configuration ---
+      gcp_project_id:
+        description: 'GCP project ID'
+        required: false
+        type: string
+        default: 'llm-d-scale'
+      gke_cluster_name:
+        description: 'GKE cluster name'
+        required: false
+        type: string
+        default: 'llm-d-e2e-tpu'
+      gke_cluster_zone:
+        description: 'GKE cluster zone'
+        required: false
+        type: string
+        default: 'us-east5'
+
+      # --- TPU requirements ---
+      tpu_type:
+        description: 'TPU chip type (e.g. v5e-8, v4-8, v5p-8)'
+        required: false
+        type: string
+        default: 'v5e-8'
+      required_tpu_chips:
+        description: 'Minimum TPU chip count required (0 for simulated)'
+        required: false
+        type: number
+        default: 8
+      recommended_tpu_chips:
+        description: 'Recommended TPU chip count for scale-up headroom'
+        required: false
+        type: number
+        default: 16
+      tpu_wait_timeout:
+        description: 'Minutes to wait for TPU chips to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
+
+      # --- Model & accelerator ---
+      model_id:
+        description: 'Model ID (empty = auto-discover from guide)'
+        required: false
+        type: string
+        default: ''
+
+      # --- Deployment configuration ---
+      helmfile_args:
+        description: 'Extra args passed to helmfile apply (e.g. --set key=val)'
+        required: false
+        type: string
+        default: ''
+      httproute_file:
+        description: 'HTTPRoute file to apply (empty = skip)'
+        required: false
+        type: string
+        default: ''
+      gateway_host:
+        description: 'Override GATEWAY_HOST for e2e-validate.sh (e.g. svc-name:port). If empty, auto-discovers from Gateway resource.'
+        required: false
+        type: string
+        default: ''
+      pre_deploy_script:
+        description: 'Script to run before deployment (e.g. slim transforms)'
+        required: false
+        type: string
+        default: ''
+      custom_deploy_script:
+        description: 'Custom deploy script — replaces helmfile apply (for kustomize/helm guides)'
+        required: false
+        type: string
+        default: ''
+      image_override:
+        description: 'Override vLLM container image (e.g. ghcr.io/llm-d/llm-d-tpu-dev:latest)'
+        required: false
+        type: string
+        default: ''
+
+      # --- Test configuration ---
+      e2e_validate_args:
+        description: 'Extra args for e2e-validate.sh (e.g. -m model-id)'
+        required: false
+        type: string
+        default: ''
+      pod_wait_timeout:
+        description: 'Timeout for pods to become ready (TPU init can be slow)'
+        required: false
+        type: string
+        default: '45m'
+      pod_readiness_delay:
+        description: 'Extra delay after pods are ready (for model loading)'
+        required: false
+        type: number
+        default: 300
+
+      # --- Cleanup ---
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        type: boolean
+        default: false
+
+      # --- PR comment-back (optional) ---
+      pr_number:
+        description: 'PR number to comment on with test results (empty = skip)'
+        required: false
+        type: string
+        default: ''
+      pr_repo:
+        description: 'Repository (owner/repo) for the PR comment (default: llm-d/llm-d)'
+        required: false
+        type: string
+        default: 'llm-d/llm-d'
+
+jobs:
+  nightly-e2e-tpu:
+    runs-on: ubuntu-latest
+    env:
+      GUIDE_NAME: ${{ inputs.guide_name }}
+      GUIDE_PATH: ${{ inputs.guide_path || format('guides/{0}', inputs.guide_name) }}
+      NAMESPACE: ${{ inputs.namespace }}
+      HELMFILE_ENV: ${{ inputs.helmfile_env }}
+      GATEWAY_TYPE: ${{ inputs.gateway_type }}
+      TPU_TYPE: ${{ inputs.tpu_type }}
+      GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
+      GKE_CLUSTER_NAME: ${{ inputs.gke_cluster_name }}
+      GKE_CLUSTER_ZONE: ${{ inputs.gke_cluster_zone }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Checkout llm-d/llm-d
+        uses: actions/checkout@v6
+        with:
+          repository: llm-d/llm-d
+          ref: ${{ inputs.llm_d_ref || github.ref }}
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@b7593ed2efd1c1617e1b0254da33b86225adb2a5
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Set up gcloud CLI and kubectl
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          install_components: 'kubectl,gke-gcloud-auth-plugin'
+
+      - name: Get GKE credentials
+        run: |
+          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" \
+            --zone "$GKE_CLUSTER_ZONE" \
+            --project "$GCP_PROJECT_ID"
+
+      - name: Install prerequisites (helm, helmfile, yq)
+        run: |
+          # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
+          ./helpers/client-setup/install-deps.sh
+
+          # Install jq if not present
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Verify cluster access
+        run: |
+          echo "Verifying GKE TPU cluster access..."
+          kubectl cluster-info
+          kubectl get nodes -L cloud.google.com/gke-tpu-accelerator,cloud.google.com/gke-tpu-topology
+
+      - name: Cordon unhealthy TPU nodes
+        run: |
+          echo "Checking for unhealthy TPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r --arg tpu_type "$TPU_TYPE" '
+            .items[] | select(
+              ((.status.allocatable["google.com/tpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy TPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All TPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
+
+      - name: Check TPU availability
+        id: tpu-check
+        env:
+          REQUIRED_TPUS: ${{ inputs.required_tpu_chips }}
+          RECOMMENDED_TPUS: ${{ inputs.recommended_tpu_chips }}
+          TPU_WAIT_TIMEOUT: ${{ inputs.tpu_wait_timeout }}
+        run: |
+          echo "Checking TPU availability for nightly e2e ($GUIDE_NAME, type: $TPU_TYPE)..."
+
+          check_tpus() {
+            TOTAL_TPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["google.com/tpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_TPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["google.com/tpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_TPUS=$((TOTAL_TPUS - ALLOCATED_TPUS))
+          }
+
+          check_tpus
+
+          NODE_COUNT=$(kubectl get nodes --no-headers | wc -l | tr -d ' ')
+          TPU_NODE_COUNT=$(kubectl get nodes -o json | \
+            jq '[.items[] | select((.status.allocatable["google.com/tpu"] // "0" | tonumber) > 0)] | length')
+
+          echo "total_tpus=$TOTAL_TPUS" >> $GITHUB_OUTPUT
+          echo "allocated_tpus=$ALLOCATED_TPUS" >> $GITHUB_OUTPUT
+          echo "available_tpus=$AVAILABLE_TPUS" >> $GITHUB_OUTPUT
+
+          echo "## TPU Status — Nightly ($GUIDE_NAME on GKE TPU)" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Cluster | $GKE_CLUSTER_NAME ($GKE_CLUSTER_ZONE) |" >> $GITHUB_STEP_SUMMARY
+          echo "| TPU Type | $TPU_TYPE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total cluster TPU chips | $TOTAL_TPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Currently allocated | $ALLOCATED_TPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Available | $AVAILABLE_TPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Required (minimum) | $REQUIRED_TPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Recommended (with scale-up) | $RECOMMENDED_TPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Nodes | $NODE_COUNT ($TPU_NODE_COUNT with TPUs) |" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$REQUIRED_TPUS" -eq 0 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**No TPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
+          elif [ "$AVAILABLE_TPUS" -lt "$REQUIRED_TPUS" ]; then
+            if [ "${TPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + TPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${TPU_WAIT_TIMEOUT}m for TPU chips (need $REQUIRED_TPUS, have $AVAILABLE_TPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for TPUs... need $REQUIRED_TPUS, have $AVAILABLE_TPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_tpus
+                if [ "$AVAILABLE_TPUS" -ge "$REQUIRED_TPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] TPU chips now available: $AVAILABLE_TPUS free"
+                  echo "available_tpus=$AVAILABLE_TPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_tpus=$ALLOCATED_TPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            if [ "$AVAILABLE_TPUS" -lt "$REQUIRED_TPUS" ]; then
+              WAIT_MSG=""
+              [ "${TPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${TPU_WAIT_TIMEOUT}m)"
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Insufficient TPUs${WAIT_MSG}** — need $REQUIRED_TPUS but only $AVAILABLE_TPUS available." >> $GITHUB_STEP_SUMMARY
+              echo "::error::Insufficient TPU chips: need $REQUIRED_TPUS, have $AVAILABLE_TPUS available${WAIT_MSG}"
+              exit 1
+            else
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**TPU chips available after waiting** — $AVAILABLE_TPUS chips free ($REQUIRED_TPUS required, $RECOMMENDED_TPUS recommended)" >> $GITHUB_STEP_SUMMARY
+            fi
+          elif [ "$AVAILABLE_TPUS" -lt "$RECOMMENDED_TPUS" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Low TPU headroom** — $AVAILABLE_TPUS available (need $RECOMMENDED_TPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY
+            echo "::warning::Low TPU headroom: $AVAILABLE_TPUS available, $RECOMMENDED_TPUS recommended"
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**TPU chips available** — $AVAILABLE_TPUS chips free ($REQUIRED_TPUS required, $RECOMMENDED_TPUS recommended)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Clean up previous nightly resources
+        run: |
+          echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
+          echo "  NAMESPACE: $NAMESPACE"
+
+          if kubectl get namespace "$NAMESPACE" &>/dev/null; then
+            echo "=== Cleaning up namespace: $NAMESPACE ==="
+
+            # Destroy helmfile releases if helmfile.yaml.gotmpl exists
+            if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+              echo "  Destroying helmfile releases..."
+              cd "$GUIDE_PATH"
+              helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" --args --ignore-not-found 2>/dev/null || true
+              cd "$GITHUB_WORKSPACE"
+            fi
+
+            # Fallback: uninstall any remaining helm releases
+            for release in $(helm list -n "$NAMESPACE" -q 2>/dev/null); do
+              echo "  Uninstalling helm release: $release"
+              helm uninstall "$release" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+            done
+
+            # Delete HTTPRoutes and other resources
+            kubectl delete httproute --all -n "$NAMESPACE" --ignore-not-found || true
+            kubectl delete gateway --all -n "$NAMESPACE" --ignore-not-found || true
+
+            echo "  Force-deleting stuck pods in $NAMESPACE..."
+            kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+            echo "  Deleting namespace: $NAMESPACE"
+            kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
+              kubectl delete namespace "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+            if kubectl get namespace "$NAMESPACE" 2>/dev/null | grep -q Terminating; then
+              echo "Warning: namespace $NAMESPACE still Terminating — clearing finalizers"
+              kubectl get namespace "$NAMESPACE" -o json | \
+                jq '.spec.finalizers = []' | \
+                kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+            fi
+          else
+            echo "Namespace $NAMESPACE does not exist, skipping"
+          fi
+
+          echo "Pre-cleanup complete"
+
+      - name: Create namespace and HF token secret
+        run: |
+          echo "Creating namespace $NAMESPACE..."
+          kubectl create namespace "$NAMESPACE" || echo "Namespace already exists"
+
+          echo "Creating HF token secret in $NAMESPACE..."
+          kubectl create secret generic llm-d-hf-token \
+            --from-literal="HF_TOKEN=$HF_TOKEN" \
+            --namespace "$NAMESPACE" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Override vLLM image
+        if: inputs.image_override != ''
+        run: |
+          set -euo pipefail
+          echo "IMAGE_OVERRIDE=${{ inputs.image_override }}" >> $GITHUB_ENV
+          echo "Overriding vLLM images to: ${{ inputs.image_override }}"
+          VALUES_FILES=$(find "$GUIDE_PATH" -name "values*.yaml")
+          if [ -z "$VALUES_FILES" ]; then
+            echo "::warning::No values*.yaml files found in $GUIDE_PATH — image override will have no effect on values files"
+          else
+            for file in $VALUES_FILES; do
+              echo "Updating vLLM image in ${file}..."
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+            done
+          fi
+        env:
+          IMAGE_OVERRIDE: ${{ inputs.image_override }}
+
+      - name: Run pre-deploy script
+        if: inputs.pre_deploy_script != ''
+        run: |
+          echo "Running pre-deploy script..."
+          ${{ inputs.pre_deploy_script }}
+
+      - name: Deploy guide via helmfile
+        if: inputs.custom_deploy_script == ''
+        run: |
+          echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV, TPU: $TPU_TYPE)..."
+          cd "$GUIDE_PATH"
+          helmfile apply -e "$HELMFILE_ENV" \
+            --namespace "$NAMESPACE" \
+            --set "gateway.service.type=LoadBalancer" \
+            --skip-schema-validation \
+            ${{ inputs.helmfile_args }} \
+            | tee /tmp/helmfile-deploy.log
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Deploy guide via custom script
+        if: inputs.custom_deploy_script != ''
+        run: |
+          echo "Deploying $GUIDE_NAME via custom script..."
+          ${{ inputs.custom_deploy_script }}
+
+      - name: Deploy HTTPRoute
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == ''
+        run: |
+          HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
+          if [ -f "$HTTPROUTE" ]; then
+            echo "Deploying HTTPRoute from $HTTPROUTE..."
+            kubectl apply -f "$HTTPROUTE" -n "$NAMESPACE"
+          else
+            echo "::warning::HTTPRoute file $HTTPROUTE not found — skipping"
+          fi
+
+      - name: Upload helm values
+        if: inputs.custom_deploy_script == ''
+        run: |
+          for release in $(helm list -n "$NAMESPACE" -q 2>/dev/null); do
+            bash .github/scripts/e2e/helm-get-all.sh \
+              /tmp/helmfile-deploy.log \
+              "$release" \
+              "$NAMESPACE" || true
+          done
+
+      - name: Show deployment status
+        run: |
+          echo "=== Deployments ==="
+          kubectl get deployments -n "$NAMESPACE" || true
+          echo ""
+          echo "=== StatefulSets ==="
+          kubectl get statefulsets -n "$NAMESPACE" || true
+          echo ""
+          echo "=== LeaderWorkerSets ==="
+          kubectl get leaderworkersets -n "$NAMESPACE" 2>/dev/null || true
+          echo ""
+          echo "=== Pods (with TPU node labels) ==="
+          kubectl get pods -n "$NAMESPACE" -o wide || true
+          echo ""
+          echo "=== Services ==="
+          kubectl get svc -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Helm releases ==="
+          helm list -n "$NAMESPACE" || true
+          echo ""
+          echo "=== InferencePools ==="
+          kubectl get inferencepools -n "$NAMESPACE" || true
+          echo ""
+          echo "=== HTTPRoutes ==="
+          kubectl get httproutes -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Gateways ==="
+          kubectl get gateway -n "$NAMESPACE" || true
+          echo ""
+          echo "=== TPU Node Allocations ==="
+          kubectl get nodes -o json | \
+            jq -r '.items[] | select((.status.allocatable["google.com/tpu"] // "0" | tonumber) > 0) |
+              [.metadata.name,
+               (.metadata.labels["cloud.google.com/gke-tpu-accelerator"] // "unknown"),
+               (.metadata.labels["cloud.google.com/gke-tpu-topology"] // "unknown"),
+               (.status.allocatable["google.com/tpu"] // "0")] | @tsv' \
+            | column -t -s $'\t' || true
+
+      # Emit image metadata early so the artifact is available while tests run.
+      - name: Emit image metadata
+        if: always()
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg tpuType "$TPU_TYPE" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              accelerator: "TPU",
+              tpuType: $tpuType,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
+      - name: Wait for pods to be ready
+        env:
+          POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
+          POD_READINESS_DELAY: ${{ inputs.pod_readiness_delay }}
+        run: |
+          echo "Waiting for all pods in $NAMESPACE to be ready (timeout: $POD_WAIT_TIMEOUT)..."
+          echo "Note: TPU pod init (chip firmware + model load) is typically slower than GPU."
+          if ! kubectl wait pod \
+            --for=condition=Ready \
+            --all \
+            -n "$NAMESPACE" \
+            --timeout="$POD_WAIT_TIMEOUT"; then
+            echo "::error::Pods in $NAMESPACE did not become ready within $POD_WAIT_TIMEOUT"
+            echo "--- Pods ---"
+            kubectl get pods -n "$NAMESPACE" -o wide || true
+            echo "--- Describe non-ready pods ---"
+            for pod in $(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "=== Pod: $pod ==="
+              kubectl describe pod "$pod" -n "$NAMESPACE" || true
+              kubectl logs "$pod" -n "$NAMESPACE" --tail=50 || true
+            done
+            exit 1
+          fi
+
+          if [ "$POD_READINESS_DELAY" -gt 0 ]; then
+            echo "Extra readiness delay: ${POD_READINESS_DELAY}s (TPU model loading)..."
+            sleep "$POD_READINESS_DELAY"
+          fi
+
+          echo "All pods in $NAMESPACE are ready"
+          kubectl get pods -n "$NAMESPACE"
+
+      - name: Run E2E validation
+        env:
+          GATEWAY_HOST: ${{ inputs.gateway_host }}
+        run: |
+          echo "Running E2E validation for $GUIDE_NAME on GKE TPU ($TPU_TYPE)..."
+          cd .github/scripts/e2e
+          ./e2e-validate.sh -n "$NAMESPACE" -v ${{ inputs.e2e_validate_args }}
+
+      - name: Nightly summary
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Nightly E2E Results — $GUIDE_NAME (GKE TPU)" >> $GITHUB_STEP_SUMMARY
+          echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Guide | $GUIDE_NAME |" >> $GITHUB_STEP_SUMMARY
+          echo "| Platform | GKE ($GKE_CLUSTER_NAME) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Accelerator | TPU $TPU_TYPE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Namespace | $NAMESPACE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Helmfile Env | $HELMFILE_ENV |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
+          echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment on PR
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN || github.token }}
+          script: |
+            const status = '${{ job.status }}';
+            const passed = status === 'success';
+            const icon = passed ? ':white_check_mark:' : ':x:';
+            const label = passed ? 'Passed' : 'Failed';
+            const guideName = '${{ inputs.guide_name }}';
+            const tpuType = '${{ inputs.tpu_type }}';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = '${{ github.sha }}'.substring(0, 7);
+
+            const [prOwner, prRepo] = '${{ inputs.pr_repo }}'.split('/');
+            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+
+            const body = [
+              `### Nightly E2E Result: \`${guideName}\` (GKE TPU ${tpuType})`,
+              '',
+              '| | |',
+              '|---|---|',
+              `| Result | ${icon} **${label}** |`,
+              `| Guide | \`${guideName}\` |`,
+              `| Accelerator | TPU \`${tpuType}\` |`,
+              `| Run | [View logs](${runUrl}) |`,
+              `| Ref | \`${sha}\` |`,
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: prNumber,
+                body,
+              });
+            } catch (err) {
+              core.warning(`Failed to comment on PR #${prNumber}: ${err.message}`);
+            }
+
+      - name: Collect pod logs
+        if: always()
+        run: |
+          mkdir -p /tmp/pod-logs-$GUIDE_NAME
+          echo "Collecting pod logs from $NAMESPACE..."
+          for pod in $(kubectl get pods -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+            kubectl logs --all-containers=true -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}.log" 2>&1 || true
+            kubectl describe pod -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}-describe.log" 2>&1 || true
+          done
+          cp /tmp/helmfile-deploy.log "/tmp/pod-logs-$GUIDE_NAME/" 2>/dev/null || true
+
+      - name: Upload pod logs
+        uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: nightly-pod-logs-${{ inputs.guide_name }}-gke-tpu
+          path: /tmp/pod-logs-${{ inputs.guide_name }}
+          retention-days: 7
+
+      - name: Send Google Chat notification on failure
+        if: failure()
+        uses: SimonScholz/google-chat-action@3b3519e5102dba8aa5046fd711c4b553586409bb
+        with:
+          webhookUrl: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          jobStatus: ${{ job.status }}
+          title: 'Nightly E2E — ${{ inputs.guide_name }} (GKE TPU ${{ inputs.tpu_type }})'
+
+      - name: Cleanup infrastructure
+        if: always() && inputs.skip_cleanup == false
+        run: |
+          echo "Cleaning up nightly test infrastructure for $GUIDE_NAME..."
+
+          # Destroy helmfile releases
+          if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+            echo "Destroying helmfile releases..."
+            cd "$GUIDE_PATH"
+            helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" 2>/dev/null || true
+            cd "$GITHUB_WORKSPACE"
+          fi
+
+          # Delete HTTPRoute
+          if [ -n "${{ inputs.httproute_file }}" ] && [ -f "$GUIDE_PATH/${{ inputs.httproute_file }}" ]; then
+            kubectl delete -f "$GUIDE_PATH/${{ inputs.httproute_file }}" -n "$NAMESPACE" --ignore-not-found || true
+          fi
+
+          # Fallback: uninstall remaining helm releases
+          for release in $(helm list -n "$NAMESPACE" -q 2>/dev/null); do
+            echo "  Uninstalling release: $release"
+            helm uninstall "$release" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          done
+
+          # Delete namespace
+          echo "Deleting namespace $NAMESPACE..."
+          kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+          kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
+            kubectl delete namespace "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          if kubectl get namespace "$NAMESPACE" 2>/dev/null | grep -q Terminating; then
+            echo "Warning: namespace $NAMESPACE still Terminating — clearing finalizers"
+            kubectl get namespace "$NAMESPACE" -o json | \
+              jq '.spec.finalizers = []' | \
+              kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+          fi
+
+          echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -167,6 +167,18 @@ on:
         type: boolean
         default: false
 
+      # --- PR comment-back (optional) ---
+      pr_number:
+        description: 'PR number to comment on with test results (empty = skip)'
+        required: false
+        type: string
+        default: ''
+      pr_repo:
+        description: 'Repository (owner/repo) for the PR comment (default: llm-d/llm-d)'
+        required: false
+        type: string
+        default: 'llm-d/llm-d'
+
 jobs:
   nightly-e2e:
     runs-on: [self-hosted, openshift, pok-prod]
@@ -858,6 +870,45 @@ jobs:
             echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
             echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Comment on PR
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN || github.token }}
+          script: |
+            const status = '${{ job.status }}';
+            const passed = status === 'success';
+            const icon = passed ? ':white_check_mark:' : ':x:';
+            const label = passed ? 'Passed' : 'Failed';
+            const guideName = '${{ inputs.guide_name }}';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = '${{ github.sha }}'.substring(0, 7);
+
+            const [prOwner, prRepo] = '${{ inputs.pr_repo }}'.split('/');
+            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+
+            const body = [
+              `### Nightly E2E Result: \`${guideName}\` (OCP)`,
+              '',
+              '| | |',
+              '|---|---|',
+              `| Result | ${icon} **${label}** |`,
+              `| Guide | \`${guideName}\` |`,
+              `| Run | [View logs](${runUrl}) |`,
+              `| Ref | \`${sha}\` |`,
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: prNumber,
+                body,
+              });
+            } catch (err) {
+              core.warning(`Failed to comment on PR #${prNumber}: ${err.message}`);
+            }
 
       - name: Collect pod logs
         if: always()


### PR DESCRIPTION
Closes #1566

## What was broken

The OCP helmfile reusable workflow was missing `pr_number` and `pr_repo`
inputs. The caller workflows for `pd-disaggregation-ocp` and
`wide-ep-lws-ocp` were already passing these values — they just had
nowhere to land, so nightly runs never commented back on the PR.

## Fix

Added the two missing input declarations and a "Comment on PR" step.
The step is identical to what `reusable-nightly-e2e-gke.yaml` already
does — just copied the pattern across.

## Changed

- `.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml`