### PR TITLE
fix(ci): exclude terminating pods from GPU available count

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -287,7 +287,7 @@ jobs:
             TOTAL_GPUS=$(kubectl get nodes -o json | \
               jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+              jq '[.items[] | select((.status.phase == "Running" or .status.phase == "Pending") and .metadata.deletionTimestamp == null) | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
           }
 

--- a/.github/workflows/reusable-nightly-e2e-gke.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke.yaml
@@ -260,7 +260,7 @@ jobs:
             TOTAL_GPUS=$(kubectl get nodes -o json | \
               jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+              jq '[.items[] | select((.status.phase == "Running" or .status.phase == "Pending") and .metadata.deletionTimestamp == null) | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
           }
 

--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -278,7 +278,7 @@ jobs:
             TOTAL_GPUS=$(kubectl get nodes -o json | \
               jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+              jq '[.items[] | select((.status.phase == "Running" or .status.phase == "Pending") and .metadata.deletionTimestamp == null) | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
           }
 

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -299,7 +299,7 @@ jobs:
             TOTAL_GPUS=$(kubectl get nodes -o json | \
               jq '[.items[].status.allocatable["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
-              jq '[.items[] | select(.status.phase == "Running" or .status.phase == "Pending") | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
+              jq '[.items[] | select((.status.phase == "Running" or .status.phase == "Pending") and .metadata.deletionTimestamp == null) | .spec.containers[]?.resources.requests["nvidia.com/gpu"] // "0" | tonumber] | add // 0')
             AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
           }
 


### PR DESCRIPTION
Closes #164

## What was wrong

When a pod is terminating, Kubernetes keeps its phase as `Running` until
it's fully gone. The GPU preflight was counting those pods as still using
GPUs, so `ALLOCATED_GPUS` could end up higher than `TOTAL_GPUS` —
giving a negative available count and aborting the deploy before it even
started.

## Fix

Added `.metadata.deletionTimestamp == null` to the jq filter so
terminating pods are skipped when counting allocated GPUs.

Same fix applied to all four reusable workflows:
- `reusable-nightly-e2e-openshift-helmfile.yaml`
- `reusable-nightly-e2e-openshift.yaml`
- `reusable-nightly-e2e-cks.yaml`
- `reusable-nightly-e2e-gke.yaml`