### PR TITLE
fix(ci): capture pod state and events when OCP pods time out

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml
@@ -706,11 +706,23 @@ jobs:
             echo "::error::Pods in $NAMESPACE did not become ready within $POD_WAIT_TIMEOUT"
             echo "--- Pods ---"
             kubectl get pods -n "$NAMESPACE" -o wide || true
+            echo "--- Namespace Events ---"
+            kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' || true
             echo "--- Describe non-ready pods ---"
-            for pod in $(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-              echo "=== Pod: $pod ==="
-              kubectl describe pod "$pod" -n "$NAMESPACE" || true
-              kubectl logs "$pod" -n "$NAMESPACE" --tail=50 || true
+            for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              READY=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+              if [ "$READY" != "True" ]; then
+                echo "=== Pod: $pod ==="
+                kubectl describe pod "$pod" -n "$NAMESPACE" || true
+                kubectl logs "$pod" -n "$NAMESPACE" --all-containers=true --tail=50 || true
+              fi
+            done
+            mkdir -p /tmp/pod-timeout-$GUIDE_NAME
+            kubectl get pods -n "$NAMESPACE" -o wide > /tmp/pod-timeout-$GUIDE_NAME/pods.txt 2>&1 || true
+            kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' > /tmp/pod-timeout-$GUIDE_NAME/events.txt 2>&1 || true
+            for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              kubectl describe pod "$pod" -n "$NAMESPACE" > /tmp/pod-timeout-$GUIDE_NAME/${pod}-describe.txt 2>&1 || true
+              kubectl logs "$pod" -n "$NAMESPACE" --all-containers=true --tail=100 > /tmp/pod-timeout-$GUIDE_NAME/${pod}-logs.txt 2>&1 || true
             done
             exit 1
           fi
@@ -729,6 +741,14 @@ jobs:
 
           echo "All pods in $NAMESPACE are ready"
           kubectl get pods -n "$NAMESPACE"
+
+      - name: Upload pod timeout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: pod-timeout-diagnostics-${{ inputs.guide_name }}
+          path: /tmp/pod-timeout-${{ inputs.guide_name }}
+          retention-days: 7
 
       - name: Wait for gateway to be ready
         run: |

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -727,11 +727,23 @@ jobs:
             echo "::error::Pods in $NAMESPACE did not become ready within $POD_WAIT_TIMEOUT"
             echo "--- Pods ---"
             kubectl get pods -n "$NAMESPACE" -o wide || true
+            echo "--- Namespace Events ---"
+            kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' || true
             echo "--- Describe non-ready pods ---"
-            for pod in $(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-              echo "=== Pod: $pod ==="
-              kubectl describe pod "$pod" -n "$NAMESPACE" || true
-              kubectl logs "$pod" -n "$NAMESPACE" --tail=50 || true
+            for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              READY=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+              if [ "$READY" != "True" ]; then
+                echo "=== Pod: $pod ==="
+                kubectl describe pod "$pod" -n "$NAMESPACE" || true
+                kubectl logs "$pod" -n "$NAMESPACE" --all-containers=true --tail=50 || true
+              fi
+            done
+            mkdir -p /tmp/pod-timeout-$GUIDE_NAME
+            kubectl get pods -n "$NAMESPACE" -o wide > /tmp/pod-timeout-$GUIDE_NAME/pods.txt 2>&1 || true
+            kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' > /tmp/pod-timeout-$GUIDE_NAME/events.txt 2>&1 || true
+            for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              kubectl describe pod "$pod" -n "$NAMESPACE" > /tmp/pod-timeout-$GUIDE_NAME/${pod}-describe.txt 2>&1 || true
+              kubectl logs "$pod" -n "$NAMESPACE" --all-containers=true --tail=100 > /tmp/pod-timeout-$GUIDE_NAME/${pod}-logs.txt 2>&1 || true
             done
             exit 1
           fi
@@ -750,6 +762,14 @@ jobs:
 
           echo "All pods in $NAMESPACE are ready"
           kubectl get pods -n "$NAMESPACE"
+
+      - name: Upload pod timeout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: pod-timeout-diagnostics-${{ inputs.guide_name }}
+          path: /tmp/pod-timeout-${{ inputs.guide_name }}
+          retention-days: 7
 
       - name: Wait for gateway to be ready
         if: inputs.install_gateway_provider


### PR DESCRIPTION
Closes llm-d/llm-d#1570

## What was missing

When pods didn't become ready in time, the diagnostic only described
pods where `phase != Running`. The problem is a pod can be in `Running`
phase but still not `Ready` — for example if a health check is failing.
Those pods were completely skipped, so the logs had nothing useful.

On top of that, Kubernetes events were never captured. Events are
usually the first place you look to understand why a pod isn't starting
— things like image pull failures, volume mount errors, OOM kills, etc.

## What this PR does

- Checks the `Ready` condition instead of `phase` to find stuck pods
- Adds `kubectl get events` capture at timeout time
- Saves everything to a `pod-timeout-diagnostics` artifact on failure
  so the next time this happens, the data is right there

Applies to both `reusable-nightly-e2e-openshift.yaml` and
`reusable-nightly-e2e-openshift-helmfile.yaml`.

This doesn't fix why pods aren't becoming ready — that needs the
artifact data first. But at least the next failure won't be opaque.