### PR TITLE
fix: remove calling install_kustomize.sh

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-cks.yaml
+++ b/.github/workflows/reusable-nightly-e2e-cks.yaml
@@ -245,9 +245,6 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-
       - name: Verify cluster access
         run: |
           echo "Verifying CKS cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
@@ -233,9 +233,6 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-
       - name: Verify cluster access
         run: |
           echo "Verifying GKE TPU cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-gke.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke.yaml
@@ -218,9 +218,6 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-
       - name: Verify cluster access
         run: |
           echo "Verifying GKE cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-openshift.yaml
+++ b/.github/workflows/reusable-nightly-e2e-openshift.yaml
@@ -256,9 +256,6 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-
       - name: Verify cluster access
         run: |
           echo "Verifying OpenShift cluster access..."

--- a/.github/workflows/reusable-nightly-e2e-xpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-xpu.yaml
@@ -127,12 +127,6 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
 
-          # Install kustomize if not present
-          if ! command -v kustomize &>/dev/null; then
-            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-            sudo mv kustomize /usr/local/bin/
-          fi
-
       - name: Install Gateway API Inference Extension CRDs
         shell: bash
         run: |


### PR DESCRIPTION

## What does this PR do?
to fix error in nightly e.g
https://github.com/llm-d/llm-d/actions/runs/26286271685/job/77374580906
```
✅ All tools installed successfully.
tar (child): ./kustomize_v*_linux_amd64.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```
after https://github.com/llm-d/llm-d/pull/1319
this is not needed to duplicate install from llm-d-infra

<!-- Describe the changes and their purpose -->

## Why is this change needed?
- we have reusable-nightly-e2e-variant.yaml calling cilent-setup/install-deps.sh from llm-d
- install-deps.sh from llm-d does install_from_tarball already
- current curl and install_kustomize.sh does not handle error well


<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
