### PR TITLE
cicd: add reusable-ci-nightly-benchmark

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -1,0 +1,310 @@
+name: CI - Generic Nightly Run Benchmark
+
+on:
+  workflow_call:
+    inputs:
+      scenario_dir:
+        description: 'Directory housing the scenarios'
+        required: false
+        type: 'string'
+        default: 'cicd'
+      standup_method:
+        description: 'Standup method to be used ("standalone","fma","modelservice","kustomize")'
+        required: false
+        type: 'string'
+        default: 'standalone'
+      cluster_provider:
+        description: 'Cluster provider targeted ("ocp","gke","cks")'
+        required: false
+        type: 'string'
+        default: 'kind-sim'
+      cluster_namespace:
+        description: 'Cluster namespace'
+        required: false
+        type: 'string'
+        default: 'llmdbenchcicd'
+      helm_release:
+        description: 'Helm release name (for modelservice)'
+        required: false
+        type: 'string'
+        default: 'lmdbenchcicdr'
+      workspace_dir:
+        description: 'Workspace directory'
+        required: false
+        type: 'string'
+        default: '/tmp/llmdbenchcicd'
+      bucket_project:
+        description: 'Project associated to the object storage bucket'
+        required: false
+        type: 'string'
+        default: 'llm-d-scale'
+      bucket_provider:
+        description: 'Type (provider of) the bucket'
+        required: false
+        type: 'string'
+        default: 'none'
+      bucket_path:
+        description: 'Path to object storage bucket'
+        required: false
+        type: 'string'
+        default: 'llm-d-benchmarks/regressions'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly", "none")'
+        required: false
+        type: 'string'
+        default: 'istio'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: false
+        type: 'string'
+        default: 'true'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        type: 'string'
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
+
+jobs:
+  ensure-nightly-build-image:
+    name: Ensure Nightly Build  Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo yq
+
+      - name: Ensure image is already built
+        run: |
+          IMAGE="ghcr.io/llm-d/llm-d-benchmark:nightly"
+          POLL=30
+          while true; do
+            creation_date=$(skopeo inspect docker://${IMAGE} | yq -r .Created) && \
+            creation_ts=$(date -d "${creation_date}" +"%s")
+            current_ts=$(date +%s) && \
+            image_age=$((current_ts - creation_ts))
+            if [[ $image_age -gt 86400 ]]; then
+              echo "Current image \"${IMAGE}\" is too old (${image_age}s). Waiting $POLL seconds and trying again..."
+              sleep $POLL
+            else
+              echo "Current image \"${IMAGE}\" is recent enough (${image_age}s)."
+              exit 0
+            fi
+          done
+        shell: bash
+
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+#    container:
+#      image: ghcr.io/llm-d/llm-d-benchmark:nightly
+    needs: [ensure-nightly-build-image]
+    timeout-minutes: 240
+
+    env:
+      LLMDBENCH_CICD_NS: ${{ inputs.cluster_namespace || 'cicd' }}
+      LLMDBENCH_CICD_R: ${{ inputs.helm_release || 'standalone' }}
+      LLMDBENCH_CICD_SCENARIO_DIR: ${{ inputs.scenario_dir || 'kind' }}
+      LLMDBENCH_CICD_TARGET: ${{ inputs.cluster_provider || 'llmdbenchcicd' }}
+      LLMDBENCH_CICD_METHOD: ${{ inputs.standup_method || 'lmdbenchcicdr' }}
+      LLMDBENCH_WORKSPACE: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicd' }}
+      LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
+      LLMDBENCH_GATEWAY_CLASS: ${{ inputs.gateway_class || 'istio' }}
+      LLMDBENCH_IS_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      LLMDBENCH_IS_VERBOSE: ${{ inputs.verbose || 'false' }}
+      LLMDBENCH_MONITORING_ENABLED: ${{ inputs.monitoring_enabled || 'true' }}
+      GCS_PATH: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      GKE_CLUSTER_NAME: llm-d-e2e-us-east5
+      GKE_CLUSTER_ZONE: us-east5
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Create Kind cluster
+        if: inputs.cluster_provider == 'kind'
+        uses: helm/kind-action@v1
+        with:
+          version: v0.31.0
+
+      - name: Authenticate to Google Cloud
+        if: inputs.bucket_provider == 'gcs'
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Set up gcloud CLI and kubectl
+        if: inputs.bucket_provider == 'gcs'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          install_components: 'kubectl,gke-gcloud-auth-plugin'
+
+      - name: Get GKE credentials
+        if: inputs.cluster_provider == 'gke'
+        run: |
+          gcloud container clusters get-credentials "${{ env.GKE_CLUSTER_NAME }}" --zone "${{ env.GKE_CLUSTER_ZONE }}"
+
+      - name: Set up kubeconfig from secret
+        if: inputs.cluster_provider != 'kind' && inputs.cluster_provider != 'gke'
+        run: |
+          mkdir -p ~/.kube
+          if [[ $LLMDBENCH_CICD_TARGET == "cks" ]]; then
+            echo "${{ secrets.KUBECONFIG_DATA_CKS }}" | base64 -d > ~/.kube/config
+          fi
+          if [[ $LLMDBENCH_CICD_TARGET == "ocp" ]]; then
+            echo "${{ secrets.KUBECONFIG_DATA_OCP }}" | base64 -d > ~/.kube/config
+          fi
+          chmod 600 ~/.kube/config
+        shell: bash
+
+      - name: Install oc (optional on install.sh)
+        if: inputs.cluster_provider != 'ocp'
+        run: |
+          # Install oc (OpenShift CLI) — optional on install.sh
+          if ! command -v oc &>/dev/null; then
+            curl -fsSL --retry 3 --retry-delay 5 -o /tmp/openshift-client-linux.tar.gz \
+              "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz"
+            mkdir -p /tmp/oc-extract
+            tar -xzf /tmp/openshift-client-linux.tar.gz -C /tmp/oc-extract
+            sudo mv /tmp/oc-extract/oc /usr/local/bin/
+            sudo mv /tmp/oc-extract/kubectl /usr/local/bin/
+            sudo chmod +x /usr/local/bin/oc
+            sudo chmod +x /usr/local/bin/kubectl
+            rm -rf /tmp/oc-extract /tmp/openshift-client-linux.tar.gz
+          fi
+
+      - name: Show cluster nodes
+        run: |
+          kubectl get node
+          exit $?
+        shell: bash
+
+      - name: Install llmdbenchmark
+        run: |
+          ./install.sh -y 2>&1
+          cp util/debug_info_on_failure.sh /usr/local/bin
+        shell: bash
+
+      - name: Set up extra command line parameters
+        run: |
+          export LLMDBENCH_EXTRA_CMD=""
+          export LLMDBENCH_EXTRA_OPERATION_CMD=""
+
+          if [[ "$LLMDBENCH_IS_DRY_RUN" == "true" ]]; then
+            export LLMDBENCH_EXTRA_CMD="--dry-run"
+          fi
+          if [[ "$LLMDBENCH_IS_VERBOSE" == "true" ]]; then
+            export LLMDBENCH_EXTRA_CMD="--verbose $LLMDBENCH_EXTRA_CMD "
+          fi
+          if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
+            export LLMDBENCH_EXTRA_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_OPERATION_CMD "
+          fi
+          echo "LLMDBENCH_EXTRA_CMD=$LLMDBENCH_EXTRA_CMD" >> $GITHUB_ENV
+          echo "LLMDBENCH_EXTRA_OPERATION_CMD=$LLMDBENCH_EXTRA_OPERATION_CMD" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cleanup target cloud
+        run: |
+          echo "### Cluster names: $(cat ~/.kube/config | yq ".clusters[].name" | sed ':a;N;$!ba;s/\n/, /g')"
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_TARGET $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $LLMDBENCH_CMD ###"
+          $LLMDBENCH_CMD
+          kubectl -n "$LLMDBENCH_CICD_NS" exec -i access-to-harness-data-workload-pvc -- bash -c "rm -rf /requests/*" || true
+        shell: bash
+
+      - name: Standup
+        run: |
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_TARGET $LLMDBENCH_EXTRA_CMD standup $LLMDBENCH_EXTRA_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $LLMDBENCH_CMD ###"
+          $LLMDBENCH_CMD
+        shell: bash
+
+      - name: Debug info (on failure)
+        if: failure()
+        run: |
+          /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+        shell: bash
+
+      - name: Run
+        run: |
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_TARGET $LLMDBENCH_EXTRA_CMD run --namespace $LLMDBENCH_CICD_NS --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $LLMDBENCH_CMD ###"
+          $LLMDBENCH_CMD
+        shell: bash
+
+      - name: Teardown
+        if: always()
+        run: |
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_TARGET $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $LLMDBENCH_CMD ###"
+          $LLMDBENCH_CMD
+          kubectl -n "$LLMDBENCH_CICD_NS" exec -i access-to-harness-data-workload-pvc -- bash -c "rm -rf /requests/*" || true
+        shell: bash
+
+      - name: Debug info (on failure)
+        if: failure()
+        run: |
+          /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+        shell: bash
+
+      - name: Upload results to GCS
+        if: inputs.cluster_provider != 'kind'
+        run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "Skipping data upload to bucket, due to \"dry-run\" mode activated"
+          else
+            RUN_DATE=$(date +'%Y-%m-%d')
+            cd "$LLMDBENCH_WORKSPACE"
+            REG_RESULTS=$(find . -name results | sed "s^/results$^^g" | cut -d '/' -f 2)
+            echo "Uploading data from directory \"REG_RESULTS\" to \"gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/$LLMDBENCH_CICD_METHOD/$RUN_DATE/\""
+            gcloud storage cp -r $REG_RESULTS/ "gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/$LLMDBENCH_CICD_METHOD/$RUN_DATE/" || true
+          fi
+        shell: bash
+
+      - name: Block waiting for Standalone baseline
+        if: inputs.cluster_provider != 'kind' && inputs.bucket_provider == 'gcs'
+        run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "Skipping waiting for \"standalone baseline\", due to \"dry-run\" mode activated"
+            exit 0
+          else
+            RUN_DATE=$(date +'%Y-%m-%d')
+            POLL=30
+            while true; do
+              brl=$(gcloud storage ls -l "gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/standalone/$RUN_DATE/*/results/*/benchmark_report_v0.2*")
+              if [[ $? -ne 0 ]]; then
+                echo "Standalone baseline for \"$RUN_DATE\" still not present. Waiting $POLL seconds and trying again..."
+                sleep $POLL
+              else
+                latest_entry=$(echo "$brl" | sort -k 2 | tail -n 2 | head -n 1 | awk '{ print $3 }')
+                latest_dir=$(echo "$latest_entry" | sed "s^gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/standalone/$RUN_DATE/^^g" | cut -d '/' -f 1)
+                echo "Standalone baseline for \"$RUN_DATE\" is \"$latest_dir\"."
+                exit 0
+              fi
+            done
+          fi
+          exit 1
+        shell: bash


### PR DESCRIPTION
## What does this PR do?

Add a new reusable workflow (nightly benchmark)

## Why is this change needed?

Both `llm-d` and `llm-d-benchmark` will share the same github actions workflow

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
