### PR TITLE
fix(nightly-xpu): update monitoring stack path to guides/recipes/observability

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-xpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-xpu.yaml
@@ -147,8 +147,8 @@ jobs:
         if: inputs.install_monitoring
         shell: bash
         run: |
-          cd docs/monitoring
-          ./scripts/install-prometheus-grafana.sh || true
+          cd guides/recipes/observability
+          ./install-prometheus-grafana.sh || true
 
       - name: Create namespace
         shell: bash


### PR DESCRIPTION
## Problem

The [Nightly - Optimized Baseline E2E (XPU)](https://github.com/llm-d/llm-d/actions/runs/26882481499) run failed at the **Install monitoring stack** step:

## Issue 
The following path is renamed.
```
docs/monitoring
```
