### PR TITLE
fix(nightly-benchmark): route xpu cluster type to self-hosted xpu runner

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -190,6 +190,9 @@ jobs:
           elif [[ "$CLUSTER_TYPE" == "rocm" ]]; then
             echo "Targetting self-hosted runners (AMD/CI)"
             RUNNERS_JSON_LIST='["rocm"]'
+          elif [[ "$CLUSTER_TYPE" == "xpu" ]]; then
+            echo "Targetting self-hosted runners (Intel XPU)"
+            RUNNERS_JSON_LIST='["xpu"]'
           else
             echo "Targetting hosted runners (non-OpenShift)"
             RUNNERS_JSON_LIST='["ubuntu-latest"]'


### PR DESCRIPTION
## Problem

The migrated Intel XPU nightly ([example failing run](https://github.com/llm-d/llm-d/actions/runs/26978826982/job/79612703844)) fails at the **Show cluster nodes** step:

```
kubectl get node
E... couldn't get current server API group list: Get "http://localhost:8080/api...": connect: connection refused
```

`localhost:8080` is kubectl's fallback when no kubeconfig/context exists — i.e. the benchmark job had no cluster.

## Root cause

The XPU nightly now calls `reusable-ci-nightly-benchmark.yaml`, which resolves `CLUSTER_TYPE=xpu` (from the workflow name). But the `set runs-on` step only had branches for `ocp` (→ self-hosted OpenShift) and `rocm` (→ `["rocm"]`); **`xpu` fell through to the `["ubuntu-latest"]` default**. So the benchmark job ran on a **GitHub-hosted** runner instead of the self-hosted Intel XPU server.

On a hosted runner none of the cluster-credential steps apply to `xpu` (`Create Kind cluster` is kind-only, `Get GKE credentials` is gke-only, `Set up kubeconfig from secret` handles only cks/ocp), so `~/.kube/config` is never created and `kubectl get node` hits `localhost:8080`. The later `debug_info_on_failure.sh: No such file` / missing-dir errors are downstream noise.

## Fix

Add an `xpu` branch to `set runs-on` that targets the self-hosted `["xpu"]` runner, mirroring how `rocm` is handled.

No kubeconfig-step change is needed: the self-hosted xpu runner already has a working `~/.kube/config` on the host (pointing at its local cluster), exactly as the previous `reusable-nightly-e2e-xpu.yaml` (hardcoded `runs-on: xpu`) assumed. With the job back on the xpu runner, none of the gke/cks/ocp branches fire and the host kubeconfig is used as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)