### PR TITLE
cicd: partial refactor of reusable nightly benchmark

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -108,7 +108,6 @@ on:
         required: false
         default: 'sanity_random.yaml'
         type: 'string'
-
       tpu_topology:
         description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
         required: false
@@ -221,7 +220,7 @@ jobs:
             RUNNERS_JSON_LIST='["xpu"]'
           elif [[ "$CLUSTER_TYPE" == "hpu" ]]; then
             echo "Targetting self-hosted runners (Intel/CI)"
-            RUNNERS_JSON_LIST='["hpu-dispatch-runner"]'                        
+            RUNNERS_JSON_LIST='["hpu-dispatch-runner"]'
           else
             echo "Targetting hosted runners (non-OpenShift)"
             RUNNERS_JSON_LIST='["ubuntu-latest"]'
@@ -243,6 +242,8 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ${{ fromJSON(needs.ensure-nightly-build-image.outputs.conditional_runs_on) }}
+#    container:
+#      image: ghcr.io/llm-d/llm-d-benchmark:nightly
     needs: [ensure-nightly-build-image]
     if: inputs.accelerator_type != 'tpu-v7'
     timeout-minutes: 240
@@ -258,10 +259,16 @@ jobs:
       LLMDBENCH_CICD_BACKEND: ${{ inputs.backend_type || 'vllm' }}
       LLMDBENCH_CICD_INFRA_PROVIDER: ${{ inputs.infra_provider || '' }}
       LLMDBENCH_CICD_CONNECTOR: ${{ inputs.connector || '' }}
+      LLMDBENCH_CICD_DATA_ACCESS_TIMEOUT: 1200
+      LLMDBENCH_CICD_WAIT_TIMEOUT: 1200
+      LLMDBENCH_CICD_JOB_TIMEOUT: 2700
+      LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT: 1200
+      LLMDBENCH_CICD_DECODE_PODS: ${{ inputs.decode_pods || 'auto' }}
+      LLMDBENCH_CICD_PREFILL_PODS: ${{ inputs.prefill_pods || 'auto' }}
       LLMDBENCH_WORKSPACE: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicd' }}
       LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
       HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
-      LLMDBENCH_GATEWAY_CLASS: ${{ inputs.gateway_class || 'istio' }}
+      LLMDBENCH_CICD_GATEWAY_CLASS: ${{ inputs.gateway_class || 'istio' }}
       LLMDBENCH_IS_DRY_RUN: ${{ inputs.dry_run || 'false' }}
       LLMDBENCH_IS_VERBOSE: ${{ inputs.verbose || 'false' }}
       LLMDBENCH_MONITORING_ENABLED: ${{ inputs.monitoring_enabled || 'true' }}
@@ -353,12 +360,12 @@ jobs:
       - name: Install specific yq version
         uses: frenck/action-setup-yq@v1
         with:
-          version: 'v4.53.2' 
+          version: 'v4.53.2'
 
       - name: Show cluster names
         run: |
           echo "### Attempting to list cluster names..."
-          if [[ -f ~/.kube/config ]]; then 
+          if [[ -f ~/.kube/config ]]; then
             echo "### Cluster names (from \"~/.kube/config\") : $(cat ~/.kube/config | yq ".clusters[].name" | sed ':a;N;$!ba;s/\n/, /g')"
           fi
           if [[ ! -z $KUBECONFIG ]]; then
@@ -368,9 +375,22 @@ jobs:
 
       - name: Show cluster nodes
         run: |
-          echo "### Attempting to list node names..."        
+          echo "### Attempting to list node names..."
           kubectl get node
-          exit $?
+        shell: bash
+
+      - name: Show cluster storageclasses
+        run: |
+          echo "### Attempting to list storage classes..."
+          kubectl get storageclass
+          if [[ $? -ne 0 ]]; then
+            exit 1
+          fi
+          IS_DEFAULT_SC=$(kubectl get storageclass  | grep "(default)" || true)
+          if [[ -z $IS_DEFAULT_SC ]]; then
+            echo "ERROR: please define a default StorageClass on your cluster"
+            exit 1
+          fi
         shell: bash
 
       - name: Request TPUs (DWS)
@@ -438,7 +458,7 @@ jobs:
             --for=condition=Ready \
             -l job-name=tpu-request-job \
             -n "$LLMDBENCH_CICD_NS" \
-            --timeout=45m
+            --timeout=$LLMDBENCH_CICD_JOB_TIMEOUT
 
           # Release the chips so test can use them
           kubectl delete job tpu-request-job -n "$LLMDBENCH_CICD_NS"
@@ -516,31 +536,6 @@ jobs:
           echo "### llm-d-benchmark code is present (branch $(git branch --show-current))"
         shell: bash
 
-      - name: Set up extra command line parameters
-        run: |
-          export LLMDBENCH_EXTRA_CMD=""
-          export LLMDBENCH_EXTRA_OPERATION_CMD=""
-          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--non-admin"
-          fi
-          if [[ "$LLMDBENCH_IS_DRY_RUN" == "true" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--dry-run"
-          fi
-          if [[ "$LLMDBENCH_IS_VERBOSE" == "true" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--verbose $LLMDBENCH_EXTRA_CMD "
-          fi
-          if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
-            export LLMDBENCH_EXTRA_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_OPERATION_CMD "
-          fi
-          echo "### LLMDBENCH_EXTRA_CMD is \"$LLMDBENCH_EXTRA_CMD\""
-          echo "LLMDBENCH_EXTRA_CMD=$LLMDBENCH_EXTRA_CMD" >> $GITHUB_ENV
-          echo "### LLMDBENCH_EXTRA_OPERATION_CMD is \"$LLMDBENCH_EXTRA_OPERATION_CMD\""
-          echo "LLMDBENCH_EXTRA_OPERATION_CMD=$LLMDBENCH_EXTRA_OPERATION_CMD" >> $GITHUB_ENV
-          export LLMDBENCH_GATEWAY_CLASS=$(echo "$LLMDBENCH_GATEWAY_CLASS" | sed 's^standalone^epponly^g')
-          echo "LLMDBENCH_GATEWAY_CLASS is \"$LLMDBENCH_GATEWAY_CLASS\""
-          echo "LLMDBENCH_GATEWAY_CLASS=$LLMDBENCH_GATEWAY_CLASS"  >> $GITHUB_ENV
-        shell: bash
-
       - name: Conditionally clone llm-d from main repo
         run: |
           #find ~ -type f -name "cks_nvshmem3.3.9.patch" -print
@@ -556,51 +551,38 @@ jobs:
           echo "### llm-d code is present (branch $(git branch --show-current))"
         shell: bash
 
-      - name: Apply overrides to scenarios
+      - name: Apply overrides to llm-d-benchmark scenarios (yaml)
         run: |
+          touch ~/work/lkcmd.txt
           if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
-            echo "### Overriding \"repoPath\" to \"$HOME/work/llm-d/llm-d\""
-            yq -i ".scenario[0].kustomize.repoPath = \"$HOME/work/llm-d/llm-d\"" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
-            if [[ $LLMDBENCH_CICD_TARGET == "gke" ]]; then
-              echo "### Setting \"Storage class\" to \"standard-rwx\""
-              yq -i '.scenario[0].storage.workloadPvc.storageClassName = "standard-rwx"' ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
-            fi
-            if [[ $LLMDBENCH_CICD_TARGET == "cks" ]]; then
-              echo "### Setting \"Storage class\" to \"shared-vast\""
-              yq -i '.scenario[0].storage.workloadPvc.storageClassName = "shared-vast"' ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
-            fi
-            if [[ $LLMDBENCH_CICD_TARGET == "ocp" ]]; then
-              echo "### Setting \"Storage class\" to \"ibm-spectrum-scale-fileset\""
-              yq -i '.scenario[0].storage.workloadPvc.storageClassName = "ibm-spectrum-scale-fileset"' ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
-            fi
             echo "### Setting \"INFRA_PROVIDER\" to \"$LLMDBENCH_CICD_INFRA_PROVIDER\""
-            yq -i ".scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER = \"$LLMDBENCH_CICD_INFRA_PROVIDER\"" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
+            lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER = \\\"$LLMDBENCH_CICD_INFRA_PROVIDER\\\"\" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
+            echo -n "$lkcmd" > ~/work/lkcmd.txt
+            eval $lkcmd
             cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER'
-            export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/ | sed 's^//^/^g')
+            if [[ ! -z $LLMDBENCH_CICD_CONNECTOR ]]; then
+            echo "### Setting \"CONNECTOR\" to \"$LLMDBENCH_CICD_CONNECTOR\""
+              lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.CONNECTOR = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
+              echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+              eval $lkcmd
+              cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR'
+            fi
+            echo "### Setting \"repoPath\" to \"$HOME/work/llm-d/llm-d\""
+            lkcmd="yq -i \".scenario[0].kustomize.repoPath = \\\"$HOME/work/llm-d/llm-d\\\"\" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
+            echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+            eval $lkcmd
+            cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.repoPath'
+            echo "### Setting \"NAMESPACE\" to \"$LLMDBENCH_CICD_NS\""
+            lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.NAMESPACE = \\\"$LLMDBENCH_CICD_NS\\\"\" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
+            echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+            eval $lkcmd
+            cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.NAMESPACE'
+            export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND | sed 's^//^/^g')
             echo "### Setting \"acceleratorBackend\" to \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\""
-            yq -i ".scenario[0].kustomize.acceleratorBackend = \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\"" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
+            lkcmd="yq -i \".scenario[0].kustomize.acceleratorBackend = \\\"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\\\"\" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
+            echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+            eval $lkcmd
             cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.acceleratorBackend'
-            echo " ### Setting priority class \"$LLMDBENCH_CICD_PRIORITY_CLASS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
-            for i in vllm decode prefill; do
-              find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -exec yq ".spec.template.spec.priorityClassName=\"$LLMDBENCH_CICD_PRIORITY_CLASS\"" -i {} \;
-              find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -print -exec yq '.spec.template.spec.priorityClassName' {} \;
-            done
-            export LLMDBENCH_CICD_DECODE_PODS="${{ inputs.decode_pods }}"
-            if [[ $LLMDBENCH_CICD_DECODE_PODS != "auto" ]]; then
-              echo "### Setting decode pods to \"$LLMDBENCH_CICD_DECODE_PODS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
-              for i in vllm decode; do
-                find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -exec yq ".spec.replicas=$LLMDBENCH_CICD_DECODE_PODS" -i {} \;
-                find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -print -exec yq ".spec.replicas" {} \;
-              done
-            fi
-            export LLMDBENCH_CICD_PREFILL_PODS="${{ inputs.prefill_pods }}"
-            if [[ $LLMDBENCH_CICD_PREFILL_PODS != "auto" ]]; then
-              echo "### Setting decode pods to \"$LLMDBENCH_CICD_PREFILL_PODS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
-              for i in prefill; do
-                find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -exec yq ".spec.replicas=$LLMDBENCH_CICD_DECODE_PODS" -i {} \;
-                find ~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/ -type f -name "patch-$i.yaml" -print -exec yq ".spec.replicas" {} \;
-              done
-            fi
           fi
           if [[ "${{ inputs.harness }}" == "nop" && "${{ inputs.scenario_dir }}" == "cicd"  ]]; then
             echo " ### Setting harness executable to \"llm-d-benchmark.py\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
@@ -608,27 +590,110 @@ jobs:
           fi
         shell: bash
 
+      - name: Handle namespace and secret (HF_TOKEN) creation in case of kustomize
+        run: |
+          cd ~
+          touch ~/work/lkcmd.txt
+          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
+            if [[ -z $LLMDBENCH_HF_TOKEN ]]; then
+              echo "#### Assigning fake value to LLMDBENCH_HF_TOKEN"
+              export LLMDBENCH_HF_TOKEN=hf_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+            else
+              export LLMDBENCH_HF_TOKEN=$(echo $LLMDBENCH_HF_TOKEN | base64 -d)
+            fi
+            echo -n $LLMDBENCH_HF_TOKEN > hf_token.txt
+            kubectl create namespace $LLMDBENCH_CICD_NS --dry-run=client -o yaml | kubectl apply -f -
+            kubectl create secret generic llm-d-hf-token --from-file=HF_TOKEN=hf_token.txt --namespace "${NAMESPACE}" --dry-run=client -o yaml
+            rm -rf hf_token.txt
+          fi
+        shell: bash
+
+      - name: Apply overrides to kustomize manifests
+        run: |
+          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
+            LLMDBENCH_CICD_KUSTOMIZE_PATH=~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/$LLMDBENCH_CICD_CONNECTOR/modelserver/$LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_INFRA_PROVIDER
+            echo "Kustomize full path is \"$LLMDBENCH_CICD_KUSTOMIZE_PATH\""
+            detected_model=$(kubectl kustomize $LLMDBENCH_CICD_KUSTOMIZE_PATH | yq .spec.template.spec.containers[0].args | grep -Ev "\- \--|\- '|\---|null" | uniq | cut -d ' ' -f 2)
+            echo "LLMDBENCH_CICD_DETECTED_MODEL is \"$detected_model\""
+            echo "LLMDBENCH_CICD_DETECTED_MODEL=$detected_model"  >> $GITHUB_ENV
+            echo " ### Setting priority class \"$LLMDBENCH_CICD_PRIORITY_CLASS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
+            for i in vllm decode prefill; do
+              find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -exec yq ".spec.template.spec.priorityClassName=\"$LLMDBENCH_CICD_PRIORITY_CLASS\"" -i {} \;
+              find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -print -exec yq '.spec.template.spec.priorityClassName' {} \;
+            done
+            if [[ $LLMDBENCH_CICD_DECODE_PODS != "auto" ]]; then
+              echo "### Setting decode pods to \"$LLMDBENCH_CICD_DECODE_PODS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
+              for i in vllm decode; do
+                find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -exec yq ".spec.replicas=$LLMDBENCH_CICD_DECODE_PODS" -i {} \;
+                find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -print -exec yq ".spec.replicas" {} \;
+              done
+            fi
+            if [[ $LLMDBENCH_CICD_PREFILL_PODS != "auto" ]]; then
+              echo "### Setting decode pods to \"$LLMDBENCH_CICD_PREFILL_PODS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
+              for i in prefill; do
+                find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -exec yq ".spec.replicas=$LLMDBENCH_CICD_DECODE_PODS" -i {} \;
+                find $LLMDBENCH_CICD_KUSTOMIZE_PATH -type f -name "patch-$i.yaml" -print -exec yq ".spec.replicas" {} \;
+              done
+            fi
+          fi
+        shell: bash
+
+      - name: Set up extra command line parameters
+        run: |
+          export LLMDBENCH_EXTRA_CMD=""
+          export LLMDBENCH_EXTRA_OPERATION_CMD=""
+          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
+            export LLMDBENCH_EXTRA_CMD="--non-admin"
+          fi
+          if [[ "$LLMDBENCH_IS_DRY_RUN" == "true" ]]; then
+            export LLMDBENCH_EXTRA_CMD="--dry-run"
+          fi
+          if [[ "$LLMDBENCH_IS_VERBOSE" == "true" ]]; then
+            export LLMDBENCH_EXTRA_CMD="--verbose $LLMDBENCH_EXTRA_CMD "
+          fi
+          #if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
+          #  export LLMDBENCH_EXTRA_OPERATION_CMD="--kustomize-deploy-timeout $LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT $LLMDBENCH_EXTRA_OPERATION_CMD "
+          #fi
+          if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
+            export LLMDBENCH_EXTRA_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_OPERATION_CMD "
+          fi
+          if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
+            export LLMDBENCH_EXTRA_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_OPERATION_CMD "
+          fi
+          echo "### LLMDBENCH_EXTRA_CMD is \"$LLMDBENCH_EXTRA_CMD\""
+          echo "LLMDBENCH_EXTRA_CMD=$LLMDBENCH_EXTRA_CMD" >> $GITHUB_ENV
+          echo "### LLMDBENCH_EXTRA_OPERATION_CMD is \"$LLMDBENCH_EXTRA_OPERATION_CMD\""
+          echo "LLMDBENCH_EXTRA_OPERATION_CMD=$LLMDBENCH_EXTRA_OPERATION_CMD" >> $GITHUB_ENV
+          export LLMDBENCH_CICD_GATEWAY_CLASS=$(echo "$LLMDBENCH_CICD_GATEWAY_CLASS" | sed 's^standalone^epponly^g')
+          echo "LLMDBENCH_CICD_GATEWAY_CLASS is \"$LLMDBENCH_CICD_GATEWAY_CLASS\""
+          echo "LLMDBENCH_CICD_GATEWAY_CLASS=$LLMDBENCH_CICD_GATEWAY_CLASS"  >> $GITHUB_ENV
+        shell: bash
+
       - name: Cleanup target cloud
         run: |
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
-          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --release $LLMDBENCH_CICD_R --gateway-class $LLMDBENCH_GATEWAY_CLASS --methods $LLMDBENCH_CICD_METHOD"
-          echo "### $LLMDBENCH_CMD ###"
-          $LLMDBENCH_CMD
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --release $LLMDBENCH_CICD_R --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $(cat ~/work/lkcmd.txt); $LLMDBENCH_CMD ###"
+          eval $LLMDBENCH_CMD
           kubectl -n "$LLMDBENCH_CICD_NS" exec -i access-to-harness-data-workload-pvc -- bash -c "rm -rf /requests/*" || true
         shell: bash
 
       - name: Standup
         run: |
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
-          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD standup $LLMDBENCH_EXTRA_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
-          echo "### $LLMDBENCH_CMD ###"
-          $LLMDBENCH_CMD
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD standup $LLMDBENCH_EXTRA_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
+          echo "### $(cat ~/work/lkcmd.txt); $LLMDBENCH_CMD ###"
+          eval $LLMDBENCH_CMD
         shell: bash
 
       - name: Debug info (on failure)
         if: failure()
         run: |
-          /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+          if [[ -f /usr/local/bin/debug_info_on_failure.sh ]]; then
+            /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+          else
+            echo "### Unable to obtain debug info"
+          fi
         shell: bash
 
       - name: Run
@@ -641,9 +706,9 @@ jobs:
           elif [[ "$LLMDBENCH_CICD_TARGET" == "cks" && "${{ inputs.standup_method }}" == "fma" ]]; then
             echo "Temporarily unable to test \"fma\" on \"cks\" clusters"
           else
-            LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD run --namespace $LLMDBENCH_CICD_NS --methods $LLMDBENCH_CICD_METHOD --harness $LLMDBENCH_CICD_HARNESS --workload $LLMDBENCH_CICD_WORKLOAD --data-access-timeout 1200"
-            echo "### $LLMDBENCH_CMD ###"
-            $LLMDBENCH_CMD
+            LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD run --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --methods $LLMDBENCH_CICD_METHOD --harness $LLMDBENCH_CICD_HARNESS --workload $LLMDBENCH_CICD_WORKLOAD --data-access-timeout $LLMDBENCH_CICD_DATA_ACCESS_TIMEOUT --wait-timeout $LLMDBENCH_CICD_WAIT_TIMEOUT"
+            echo "### $(cat ~/work/lkcmd.txt); $LLMDBENCH_CMD ###"
+            eval $LLMDBENCH_CMD
           fi
         shell: bash
 
@@ -651,7 +716,7 @@ jobs:
         if: always()
         run: |
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
-          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
           echo "### $LLMDBENCH_CMD ###"
           $LLMDBENCH_CMD
           kubectl -n "$LLMDBENCH_CICD_NS" exec -i access-to-harness-data-workload-pvc -- bash -c "rm -rf /requests/*" || true
@@ -660,7 +725,11 @@ jobs:
       - name: Debug info (on failure)
         if: failure()
         run: |
-          /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+          if [[ -f /usr/local/bin/debug_info_on_failure.sh ]]; then
+            /usr/local/bin/debug_info_on_failure.sh "$LLMDBENCH_CICD_NS"
+          else
+            echo "### Unable to obtain debug info"
+          fi
         shell: bash
 
       - name: Upload results to GCS
@@ -704,4 +773,3 @@ jobs:
           fi
           exit 1
         shell: bash
-


### PR DESCRIPTION
## What does this PR do?

Partial refactor of reusable nightly benchmark

IMPORTANT: this worklfow was tested, in `dry-run` mode, in `llm-d-benchmark`

https://github.com/llm-d/llm-d-benchmark/actions/runs/27035663937/job/79798946799?pr=1464

## Why is this change needed?

Bugfix: it allows CICD to test models by managing its own creation of a secret containing and `HF_TOKEN``
Improvement: Better debugging and checking of pre-requisites (such as need for an `storageclass`
Improvement: Some `steps` divided in separate individual sub-steps, for better maintainability

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
