### PR TITLE
Updated timeouts for benchmark run completion

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -142,7 +142,7 @@ on:
         description: 'Timeout in seconds to wait for benchmark pods to complete'
         required: false
         type: 'string'
-        default: '1200'
+        default: '10800'
       job_timeout:
         description: 'Timeout for the Kubernetes job itself (e.g. 2700s)'
         required: false
@@ -152,7 +152,7 @@ on:
         description: 'Timeout in seconds for kustomize standup deploy'
         required: false
         type: 'string'
-        default: '1200'
+        default: '2400'
 
 #  push:
 #    branches:
@@ -271,7 +271,7 @@ jobs:
 #      image: ghcr.io/llm-d/llm-d-benchmark:nightly
     needs: [ensure-nightly-build-image]
     if: inputs.accelerator_type != 'tpu-v7'
-    timeout-minutes: 240
+    timeout-minutes: 360
 
     env:
       LLMDBENCH_CICD_NS: ${{ inputs.cluster_namespace || 'llmdbenchcicd' }}
@@ -286,9 +286,9 @@ jobs:
       LLMDBENCH_CICD_CONNECTOR: ${{ inputs.connector || '' }}
       LLMDBENCH_CICD_CLEANUP: ${{ inputs.cleanup || 'true' }}
       LLMDBENCH_CICD_DATA_ACCESS_TIMEOUT: ${{ inputs.data_access_timeout || '1200' }}
-      LLMDBENCH_CICD_WAIT_TIMEOUT: ${{ inputs.wait_timeout || '1200' }}
+      LLMDBENCH_CICD_WAIT_TIMEOUT: ${{ inputs.wait_timeout || '10800' }}
       LLMDBENCH_CICD_JOB_TIMEOUT: ${{ inputs.job_timeout || '2700s' }}
-      LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT: ${{ inputs.kustomize_standup_timeout || '1200' }}
+      LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT: ${{ inputs.kustomize_standup_timeout || '2400' }}
       LLMDBENCH_CICD_RUN_WAIT_TIMEOUT: ${{ inputs.run_wait_timeout || '3600' }}
       LLMDBENCH_CICD_RUN_PVC_BIND_TIMEOUT: ${{ inputs.run_pvc_bind_timeout || '1200' }}
       LLMDBENCH_CICD_DECODE_PODS: ${{ inputs.decode_pods || 'auto' }}


### PR DESCRIPTION
## What does this PR do?

Updated timeouts for benchmark run completion

## Why is this change needed?

Some benchmark workloads require multiple hours for completion

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [X] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
