### PR TITLE
Add a new reusable to count number of successful runs over a given number of days

### DIFF
--- a/.github/workflows/reusable-query-success-past-runs.yaml
+++ b/.github/workflows/reusable-query-success-past-runs.yaml
@@ -1,0 +1,43 @@
+name: Check for at least one success on past runs
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'optimized-baseline-gke-acc-gpu-vllm-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+jobs:
+  check_for_success:
+    runs-on: ubuntu-latest
+    env:
+      WNQ: ${{ inputs.workflow_name_query || 'optimized-baseline-gke-acc-gpu-vllm-x.yaml' }}
+      TWQ: ${{ inputs.time_window_query || '5' }}
+      BQ: ${{ inputs.branch_query || 'main' }}
+    steps:
+      - name: Count successes on the past days
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run list -w $WNQ \
+          -b $BQ \
+          -s success \
+          --limit 200 \
+          --json databaseId,createdAt,status,conclusion,url \
+          --jq ".[] | select(.createdAt > (now - ($TWQ * 86400) | strftime(\"%Y-%m-%dT%H:%M:%SZ\")))" > /tmp/results
+          if [[ $(cat /tmp/results | jq -s 'length') -gt 0 ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION

## What does this PR do?

New reusable to populate badges on guide's `README.md`

## Why is this change needed?

A guide `README.md` should not indicate **transient** failures on a daily basis

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [] Unit tests added/updated
- [] Integration/e2e tests added/updated
- [] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [X] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
