### PR TITLE
Support tpu/v6 and tpu/v7 formats in reusable benchmark workflow

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -266,7 +266,7 @@ jobs:
   skip-v7-warning:
     name: Skip TPU v7 Run
     runs-on: ubuntu-latest
-    if: inputs.accelerator_type == 'tpu-v7'
+    if: inputs.accelerator_type == 'tpu-v7' || inputs.accelerator_type == 'tpu/v7'
     steps:
       - name: Print skip message
         run: |
@@ -280,7 +280,7 @@ jobs:
 #    container:
 #      image: ghcr.io/llm-d/llm-d-benchmark:nightly
     needs: [ensure-nightly-build-image]
-    if: inputs.accelerator_type != 'tpu-v7'
+    if: inputs.accelerator_type != 'tpu-v7' && inputs.accelerator_type != 'tpu/v7'
     timeout-minutes: 240
 
     env:
@@ -479,13 +479,10 @@ jobs:
           kubectl create namespace "$LLMDBENCH_CICD_NS" || echo "Namespace already exists"
 
           # Map accelerator_type (tpu-v6, tpu-v7) to GKE accelerator resource name
-          if [[ "$LLMDBENCH_CICD_ACCELERATOR" == "tpu-v6" ]]; then
+          if [[ "$LLMDBENCH_CICD_ACCELERATOR" == *"v6"* ]]; then
             ACCELERATOR="tpu-v6e-slice"
-          elif [[ "$LLMDBENCH_CICD_ACCELERATOR" == "tpu-v7" ]]; then
-            ACCELERATOR="tpu7x"
           else
-            echo "::error::Unsupported TPU accelerator type: $LLMDBENCH_CICD_ACCELERATOR"
-            exit 1
+            ACCELERATOR="tpu7x"
           fi
 
           TOPOLOGY="$TPU_TOPOLOGY"


### PR DESCRIPTION
Enables using slash paths for TPU accelerators in GKE nightly workflows.