### PR TITLE
docs(upstream-versions): bump LWS pin to 0.9.0

### DIFF
--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -52,7 +52,7 @@ Pinned in `guides/prereq/gateway-provider/`:
 
 | Dependency | Current Pin | File Location | Notes |
 |-----------|-------------|---------------|-------|
-| **LeaderWorkerSet (LWS)** | `0.7.0` | `e2e-wide-ep-accelerator-test.yaml` line 387 | Also in nightly LWS workflows |
+| **LeaderWorkerSet (LWS)** | `0.9.0` | `llm-d/llm-d`: `install-lws.sh` (`LWS_VERSION`), `ci-kustomize-dry-run.yaml` CRD URL | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws); pin update: [llm-d/llm-d#1858](https://github.com/llm-d/llm-d/pull/1858); upgrade note: [kubernetes-sigs/lws#880](https://github.com/kubernetes-sigs/lws/issues/880) |
 | **InferencePool (GKE)** | `v1.2.1` | `e2e-wide-ep-accelerator-gke.yaml` line 45 | **STALE** — helmfiles use v1.3.0 |
 
 ## Hardware-Specific vLLM Images


### PR DESCRIPTION
## Summary

- Update the LWS entry in `docs/upstream-versions.md` from `0.7.0` to `0.9.0`.
- Replace the stale file location with the current pin locations in `llm-d/llm-d`.
- Keep links to the upstream LWS repo, the consuming repo pin update, and the Helm upgrade note.

## Companion PR

Companion to https://github.com/llm-d/llm-d/pull/1858, which updates the actual LWS pins in the consuming repo.

This PR should stay draft until that companion PR merges, because `docs/upstream-versions.md` tracks the consuming repo's current pin.

## Test plan

- [x] Ran `scripts/check-upstream-releases.sh`
- [x] Verified LWS is parsed as `kubernetes-sigs/lws` with current pin `0.9.0`