### PR TITLE
In case `llmdbenchmark` failed to install, do not attempt a teardown

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -893,6 +893,11 @@ jobs:
           if [[ $LLMDBENCH_CICD_CLEANUP == 'false' ]]; then
             exit 0
           fi
+          HAS_LLMDBENCHMARK_VERSION=$(llmdbenchmark 2>&1 --version | grep '^llmdbenchmark:' | cut -d ':' -f 2 || true)
+          if [[ -z $HAS_LLMDBENCHMARK_VERSION ]]; then
+            echo "### llmdbenchmark was not even installed, will not attempt to teardown"
+            exit 0
+          fi
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
           LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown $LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD  --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
           echo "### $LLMDBENCH_CMD ###"


### PR DESCRIPTION
## What does this PR do?

In case `llmdbenchmark` failed to install, do not attempt a teardown

## Why is this change needed?

This would wrongly point the cause of failure to be `infra`, instead of `prereqs`

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

NA