### PR TITLE
List node resources in case worklfow is executed in "verbose" mode

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -438,6 +438,21 @@ jobs:
           kubectl get node
         shell: bash
 
+      - name: Show cluster annotations, labels and resources
+        if: env.LLMDBENCH_IS_VERBOSE == 'tru'
+        id: infra_show_cluster_nodes_deep
+        run: |
+          echo "### Attempting to show node annotations..."
+          kubectl get nodes -o json | jq -r '.items[].metadata.annotations'
+          echo ""
+          echo "### Attempting to show node labels..."
+          kubectl get nodes -o json | jq -r '.items[].metadata.labels'
+          echo ""
+          echo "### Attempting to show node resources..."
+          kubectl get nodes -o json | jq -r '.items[].status.allocatable'
+          echo ""
+        shell: bash
+
       - name: Show cluster storageclasses
         id: infra_show_cluster_storageclasses
         run: |


### PR DESCRIPTION
## What does this PR do?

List node resources in case worklfow is executed in "verbose" mode

## Why is this change needed?

In order to "auto-detect" accelerators, the correct `resources` and `labels` need to be in place.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

NA