### PR TITLE
Fix kustomize connector selection in reusable-ci-nightly-benchmark

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -778,7 +778,7 @@ jobs:
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
           eval $lkcmd
           cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.NAMESPACE'
-          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND | sed 's^//^/^g')
+          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/$LLMDBENCH_CICD_OFFLOADING_TARGET | sed -e 's^//^/^g' -e 's^/$^^g')
           echo "### Setting \"acceleratorBackend\" to \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
           lkcmd="yq -i \".scenario[0].kustomize.acceleratorBackend = \\\"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt


### PR DESCRIPTION
This PR fixes kustomize connector selection when non-default connectors/offloading targets are requested.

### Root Cause / Default Path Resolution
Without this change, `LLMDBENCH_CICD_BACKEND_ACCELERATOR` was set to `gpu/vllm`. Since `llmdbenchmark` selects the first matching command in the guide's README containing `modelserver/{acceleratorBackend}`, it always resolved the modelserver path to:
`guides/tiered-prefix-cache/modelserver/gpu/vllm/native/cpu/gke` (the native CPU offloading path)
instead of the requested LMCache path:
`guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/gke`

### Fix
Includes the connector name and offloading target in `LLMDBENCH_CICD_BACKEND_ACCELERATOR` so that `llmdbenchmark` correctly resolves the exact kustomize path to deploy.