### PR TITLE
Revert LLMDBENCH_CICD_BACKEND_ACCELERATOR connector path override

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -778,7 +778,7 @@ jobs:
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
           eval $lkcmd
           cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.NAMESPACE'
-          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/$LLMDBENCH_CICD_OFFLOADING_TARGET | sed -e 's^//^/^g' -e 's^/$^^g')
+          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND | sed 's^//^/^g')
           echo "### Setting \"acceleratorBackend\" to \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
           lkcmd="yq -i \".scenario[0].kustomize.acceleratorBackend = \\\"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt


### PR DESCRIPTION
This PR reverts the path overrides to LLMDBENCH_CICD_BACKEND_ACCELERATOR introduced in PR #208. The selection logic has been properly fixed in llm-d-benchmark (pull #1538) by checking connector and variant overrides during the kustomize selection step.