### PR TITLE
fix(ci): Add guide variable override for ACCELERATOR and BACKEND in nightly CI workflow

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -749,6 +749,18 @@ jobs:
           eval $lkcmd
           cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.ROUTER_CHART_VERSION'
           #
+          echo "### Setting \"ACCELERATOR\" to \"$LLMDBENCH_CICD_ACCELERATOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.ACCELERATOR = \\\"$LLMDBENCH_CICD_ACCELERATOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.ACCELERATOR'
+          #
+          echo "### Setting \"BACKEND\" to \"$LLMDBENCH_CICD_BACKEND\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.BACKEND = \\\"$LLMDBENCH_CICD_BACKEND\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.BACKEND'
+          #
           if [[ ! -z $LLMDBENCH_CICD_CONNECTOR ]]; then
             echo "### Setting \"CONNECTOR\" to \"$LLMDBENCH_CICD_CONNECTOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
             lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.CONNECTOR = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"


### PR DESCRIPTION
## What does this PR do?

Adds yq overrides for `ACCELERATOR` and `BACKEND` to the kustomize-scenario
override step in `reusable-ci-nightly-benchmark.yaml`. After this change, both variables are written into `kustomize.guideVariableOverrides` of the caller's scenario YAML, alongside the existing `INFRA_PROVIDER`,
`REPO_ROOT` ... 
The new patches are unguarded (no `if [[ ! -z ... ]]`) because the corresponding workflow inputs `accelerator_type` and `backend_type` have non-empty defaults (`gpu` and `vllm`).

## Why is this change needed?

Lets a single guide README parameterize `${ACCELERATOR}` and `${BACKEND}` in its `kubectl apply -k .../modelserver/${ACCELERATOR}/${BACKEND}/...` command and have the CI fan out across deployment variants.

Without this, a single README could not drive multiple workflows, e.g. both `gpu/vllm` and `tpu/vllm`.

The values are sourced from the same `LLMDBENCH_CICD_ACCELERATOR` / `LLMDBENCH_CICD_BACKEND` env vars already used to derive `acceleratorBackend` (the kustomize path-swap key), so the README placeholder substitution and the kustomize path swap cannot drift.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

Not sure what tests can be done here. 

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

llm-d/llm-d#1927