### PR TITLE
remove hold tag from release branches

### DIFF
--- a/.github/workflows/reusable-non-main-gatekeeper.yaml
+++ b/.github/workflows/reusable-non-main-gatekeeper.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add hold label when base branch is not main
-        if: github.event.pull_request.base.ref != 'main'
+        if: github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release-')
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The gatekeeper's intent (extra caution on non-main branches) is to prevent accidental merges to arbitrary feature branches.However, the only branch that is allowed at this moment is `main`. 
**This PR update the condition to only fire on branches that aren't `main` AND aren't `release-*`.**

