### PR TITLE
Add post-run verification hook to nightly benchmark workflow

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -141,9 +141,9 @@ on:
         required: false
         default: 'sanity_random.yaml'
         type: 'string'
-      validate_script:
+      verification_script:
         description: |
-          Path to a validation script relative to the llm-d repo root. 
+          Path to a verification script relative to the llm-d repo root.
           inherits the full job environment.
         required: false
         type: 'string'
@@ -200,7 +200,7 @@ on:
         default: '2400'
     outputs:
       failure_category:
-        description: 'Category of the first failed step (prepare, prereqs, infra, guide, benchmark, validate)'
+        description: 'Category of the first failed step (prepare, prereqs, infra, guide, benchmark, verify)'
         value: ${{ jobs.benchmark.outputs.failure_category }}
 
 #  push:
@@ -973,23 +973,23 @@ jobs:
           fi
         shell: bash
 
-      - name: Run post-run validation script
-        id: benchmark_validate
+      - name: Run post-run verification script
+        id: benchmark_verify
         if: |
-          inputs.validate_script != ''
+          inputs.verification_script != ''
         timeout-minutes: 10
         run: |
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
-            echo "Skipping validation script, due to \"dry-run\" mode activated"
+            echo "Skipping verification script, due to \"dry-run\" mode activated"
             exit 0
           fi
-          VALIDATION_SCRIPT="$HOME/work/llm-d/llm-d/${{ inputs.validate_script }}"
-          if [[ ! -f "$VALIDATION_SCRIPT" ]]; then
-            echo "::error::validate_script='${{ inputs.validate_script }}' set but $VALIDATION_SCRIPT does not exist"
+          VERIFICATION_SCRIPT="$HOME/work/llm-d/llm-d/${{ inputs.verification_script }}"
+          if [[ ! -f "$VERIFICATION_SCRIPT" ]]; then
+            echo "::error::verification_script='${{ inputs.verification_script }}' set but $VERIFICATION_SCRIPT does not exist"
             exit 1
           fi
-          echo "Running post-run validation: $VALIDATION_SCRIPT"
-          "$VALIDATION_SCRIPT"
+          echo "Running post-run verification: $VERIFICATION_SCRIPT"
+          "$VERIFICATION_SCRIPT"
         shell: bash
 
       - name: Teardown
@@ -1073,8 +1073,8 @@ jobs:
           CATEGORY=""
           if [ "${{ steps.benchmark_run.outcome }}" = "failure" ]; then
             CATEGORY="benchmark"
-          elif [ "${{ steps.benchmark_validate.outcome }}" = "failure" ]; then
-            CATEGORY="validate"
+          elif [ "${{ steps.benchmark_verify.outcome }}" = "failure" ]; then
+            CATEGORY="verify"
           elif [ "${{ steps.guide_standup.outcome }}" = "failure" ] || \
                [ "${{ steps.guide_teardown.outcome }}" = "failure" ] || \
                [ "${{ steps.guide_teardown_again.outcome }}" = "failure" ]; then

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -973,7 +973,7 @@ jobs:
           fi
         shell: bash
 
-      - name: Run validation script
+      - name: Run post-run validation script
         id: benchmark_validate
         if: |
           inputs.validate_script != '' &&

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -97,10 +97,10 @@ on:
         type: 'string'
         default: 'epponly'
       monitoring_enabled:
-        description: 'Enabled monitoring ("true", "false")'
+        description: 'Enable monitoring: "true", "false", "auto".'
         required: false
         type: 'string'
-        default: 'true'
+        default: 'auto'
       gaie_version:
         description: 'Gateway API Inference Extension ("v1.5.0")'
         required: false
@@ -141,6 +141,13 @@ on:
         required: false
         default: 'sanity_random.yaml'
         type: 'string'
+      validate_script:
+        description: |
+          Path to a validation script relative to the llm-d repo root. 
+          ci environment variables are available to it.
+        required: false
+        type: 'string'
+        default: ''
       cleanup:
         description: 'Cleanup the llm-d stack stood up by this workflow'
         required: false
@@ -193,7 +200,7 @@ on:
         default: '2400'
     outputs:
       failure_category:
-        description: 'Category of the first failed step (prepare, prereqs, infra, guide, benchmark)'
+        description: 'Category of the first failed step (prepare, prereqs, infra, guide, benchmark, validate)'
         value: ${{ jobs.benchmark.outputs.failure_category }}
 
 #  push:
@@ -868,10 +875,19 @@ jobs:
           if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
             export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--model $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
           fi
-          if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
-            export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
-            export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
-          fi
+          case "$LLMDBENCH_MONITORING_ENABLED" in
+            false)
+              export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
+              export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
+              ;;
+            true)
+              export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--monitoring $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
+              export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--monitoring $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
+              ;;
+            auto|*)
+              # Scenario defaults apply unchanged
+              ;;
+          esac
           if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
             export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
             export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
@@ -957,6 +973,23 @@ jobs:
           fi
         shell: bash
 
+      - name: Run validation script
+        id: benchmark_validate
+        if: |
+          inputs.validate_script != '' &&
+          steps.benchmark_run.outcome == 'success' &&
+          inputs.dry_run != 'true'
+        timeout-minutes: 10
+        run: |
+          VALIDATION_SCRIPT="~/work/llm-d/llm-d/${{ inputs.validate_script }}"
+          if [[ ! -f "$VALIDATION_SCRIPT" ]]; then
+            echo "::error::validate_script='${{ inputs.validate_script }}' set but $VALIDATION_SCRIPT does not exist"
+            exit 1
+          fi
+          echo "Running post-run validation: $VALIDATION_SCRIPT"
+          "$VALIDATION_SCRIPT"
+        shell: bash
+
       - name: Teardown
         id: guide_teardown_again
         if: always()
@@ -1038,6 +1071,8 @@ jobs:
           CATEGORY=""
           if [ "${{ steps.benchmark_run.outcome }}" = "failure" ]; then
             CATEGORY="benchmark"
+          elif [ "${{ steps.benchmark_validate.outcome }}" = "failure" ]; then
+            CATEGORY="validate"
           elif [ "${{ steps.guide_standup.outcome }}" = "failure" ] || \
                [ "${{ steps.guide_teardown.outcome }}" = "failure" ] || \
                [ "${{ steps.guide_teardown_again.outcome }}" = "failure" ]; then

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -981,7 +981,7 @@ jobs:
           inputs.dry_run != 'true'
         timeout-minutes: 10
         run: |
-          VALIDATION_SCRIPT="~/work/llm-d/llm-d/${{ inputs.validate_script }}"
+          VALIDATION_SCRIPT="$HOME/work/llm-d/llm-d/${{ inputs.validate_script }}"
           if [[ ! -f "$VALIDATION_SCRIPT" ]]; then
             echo "::error::validate_script='${{ inputs.validate_script }}' set but $VALIDATION_SCRIPT does not exist"
             exit 1

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -144,7 +144,7 @@ on:
       validate_script:
         description: |
           Path to a validation script relative to the llm-d repo root. 
-          ci environment variables are available to it.
+          inherits the full job environment.
         required: false
         type: 'string'
         default: ''
@@ -976,11 +976,13 @@ jobs:
       - name: Run post-run validation script
         id: benchmark_validate
         if: |
-          inputs.validate_script != '' &&
-          steps.benchmark_run.outcome == 'success' &&
-          inputs.dry_run != 'true'
+          inputs.validate_script != ''
         timeout-minutes: 10
         run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "Skipping validation script, due to \"dry-run\" mode activated"
+            exit 0
+          fi
           VALIDATION_SCRIPT="$HOME/work/llm-d/llm-d/${{ inputs.validate_script }}"
           if [[ ! -f "$VALIDATION_SCRIPT" ]]; then
             echo "::error::validate_script='${{ inputs.validate_script }}' set but $VALIDATION_SCRIPT does not exist"


### PR DESCRIPTION
## What does this PR do?

This PR adds a `verification_script` input that lets each nightly caller plug in a
post-run verifier. The script lives in the `llm-d` repo, and inherits the full job env — so it can do threshold checks, vLLM `/metrics` analysis...
Empty default = no verification runs (current behavior preserved).

`monitoring_enabled` changes are to change the `"true"` option to set `--monitoring` in the llmdbenchmark command, and the default is unchanged (`"auto"`), and `"false"` behavior is unchanged.

## Why is this change needed?

Today, the reusable nightly benchmark workflow runs the harness and stops —
**no post-run verification happens at all**. Result artifacts are uploaded to GCS and never looked at 
again until a human opens them, while llm-d could have not worked as intended.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated (follow-up)
- [x] Manual testing performed (YAML validation)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [x] Documentation updated — embedded in the input description
