### PR TITLE
Point CI to the router build from head rather than latest release

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -117,10 +117,10 @@ on:
         type: 'string'
         default: 'oci://ghcr.io/llm-d/charts/llm-d-router-gateway'
       router_chart_version:
-        description: 'llm-d-router version ("v0.9.0")'
+        description: 'llm-d-router version ("v0" for latest, "v0.x.0" for a released chart)'
         required: false
         type: 'string'
-        default: 'v0.9.0'
+        default: 'v0'
       dry_run:
         description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false

--- a/.github/workflows/reusable-nightly-e2e-xpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-xpu.yaml
@@ -53,7 +53,7 @@ on:
         description: 'OCI URI for the router helm chart.'
         required: false
         type: string
-        default: 'oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev'
+        default: 'oci://ghcr.io/llm-d/charts/llm-d-router-standalone'
       router_chart_version:
         description: 'Version for the router chart.'
         required: false


### PR DESCRIPTION
## What does this PR do?

Points CI to the router build from main instead of the latest release

## Why is this change needed?

To ensure CI covers the latest changes.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
