### PR TITLE
fix(ci): fix TPU request job cleanup and idempotency on DWS timeout

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -582,6 +582,7 @@ jobs:
         if: env.LLMDBENCH_CICD_TARGET == 'gke' && contains(inputs.accelerator_type, 'tpu') && inputs.tpu_chips > 0
         run: |
           kubectl create namespace "$LLMDBENCH_CICD_NS" || echo "Namespace already exists"
+          kubectl delete job tpu-request-job -n "$LLMDBENCH_CICD_NS" --ignore-not-found
 
           # Map accelerator_type (tpu/v6, tpu-v6, tpu/v7, tpu-v7) to GKE accelerator resource name
           if [[ "$LLMDBENCH_CICD_ACCELERATOR" == "tpu/v6" || "$LLMDBENCH_CICD_ACCELERATOR" == "tpu-v6" ]]; then
@@ -644,6 +645,7 @@ jobs:
             -l job-name=tpu-request-job \
             -n "$LLMDBENCH_CICD_NS" \
             --timeout=$LLMDBENCH_CICD_JOB_TIMEOUT
+
           # Export topology and accelerator so subsequent steps (like scenario overrides) can read them
           echo "TPU_ACCELERATOR=$ACCELERATOR" >> $GITHUB_ENV
           echo "TPU_TOPOLOGY=$TOPOLOGY" >> $GITHUB_ENV
@@ -658,10 +660,10 @@ jobs:
 
       - name: Cleanup TPU DWS Request
         id: infra_clean_tpus
-        if: always() && env.LLMDBENCH_CICD_TARGET == 'gke' && contains(inputs.accelerator_type, 'tpu') && inputs.tpu_chips > 0
+        if: always() && steps.infra_request_tpus.outcome != 'skipped'
         run: |
           # Release the chips so test can use them
-          kubectl delete job tpu-request-job -n "$LLMDBENCH_CICD_NS"
+          kubectl delete job tpu-request-job -n "$LLMDBENCH_CICD_NS" --ignore-not-found
 
       - name: Create nightly PriorityClass
         id: infra_create_nightly_prioclass

--- a/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
+++ b/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml
@@ -190,6 +190,7 @@ on:
         type: string
         default: 'llm-d/llm-d'
 
+jobs:
   skip-v7-warning:
     name: Skip TPU v7 Run
     runs-on: ubuntu-latest
@@ -260,11 +261,13 @@ on:
           kubectl cluster-info
 
       - name: Request TPUs (DWS)
+        id: infra_request_tpus
         if: inputs.tpu_chips > 0
         run: |
           CHIPS_TO_REQUEST="${{ inputs.tpu_chips }}"
 
           kubectl create namespace "$NAMESPACE" || echo "Namespace already exists"
+          kubectl delete job tpu-request-job -n "$NAMESPACE" --ignore-not-found
 
           ACCELERATOR="$TPU_TYPE"
           TOPOLOGY="$TPU_TOPOLOGY"
@@ -326,9 +329,6 @@ on:
             -n "$NAMESPACE" \
             --timeout=45m
 
-          # Release the chips so test can use them
-          kubectl delete job tpu-request-job -n "$NAMESPACE"
-
           # Export topology and accelerator so subsequent steps (like scenario overrides) can read them
           echo "TPU_ACCELERATOR=$ACCELERATOR" >> $GITHUB_ENV
           echo "TPU_TOPOLOGY=$TOPOLOGY" >> $GITHUB_ENV
@@ -340,6 +340,12 @@ on:
           echo "| TPU Accelerator | $ACCELERATOR |" >> $GITHUB_STEP_SUMMARY
           echo "| TPU Topology | $TOPOLOGY |" >> $GITHUB_STEP_SUMMARY
           echo "| Requested Chips | $CHIPS_TO_REQUEST |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Release TPU Request Job
+        id: infra_release_tpus
+        if: always() && steps.infra_request_tpus.outcome != 'skipped'
+        run: |
+          kubectl delete job tpu-request-job -n "$NAMESPACE" --ignore-not-found
 
       - name: Clean up previous nightly resources
         run: |


### PR DESCRIPTION
## What does this PR do?

### Problem
In `reusable-ci-nightly-benchmark.yaml` and `reusable-nightly-e2e-gke-tpu.yaml`, the `tpu-request-job` cleanup command (`kubectl delete job tpu-request-job`) was placed at the end of the `Request TPUs (DWS)` step after `kubectl wait`. When `kubectl wait` timed out due to TPU capacity constraints:
1. The step failed immediately, skipping job deletion.
2. `llmdbenchmark` was not installed, causing the teardown step to skip namespace cleanup.
3. On subsequent runs, `kubectl apply` returned `unchanged` without spawning new pods, causing `kubectl wait` to immediately fail with `error: no matching resources found`, latching the pipeline red.
### Solution
1. **Idempotent Pre-Cleanup**: Added `kubectl delete job tpu-request-job -n "$NS" --ignore-not-found` before applying the job manifest.
2. **Guaranteed Release Step**: Extracted job deletion into a separate `Release TPU Request Job` step with `if: always() && steps.infra_request_tpus.outcome != 'skipped'` so the job is deleted even if `kubectl wait` times out or fails.

## Why is this change needed?

See #232

## How was this tested?

Will need to verify in CI/CD. The change itself is very small though.

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
