### PR TITLE
fix(ci): apply the nightly PriorityClass by manifest kind and to the TPU DWS request

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -565,6 +565,23 @@ jobs:
           rm pvc.yaml
         shell: bash
 
+      - name: Create nightly PriorityClass
+        id: infra_create_nightly_prioclass
+        run: |
+          echo "Creating PriorityClass \"$LLMDBENCH_CICD_PRIORITY_CLASS\"..."
+          cat <<PRIORITY_EOF > prioclass.yaml
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          metadata:
+            name: $LLMDBENCH_CICD_PRIORITY_CLASS
+          value: 1000000
+          preemptionPolicy: PreemptLowerPriority
+          globalDefault: false
+          description: "High priority for nightly CI/CD llm-d workloads — preempts default-priority pods"
+          PRIORITY_EOF
+          kubectl apply -f prioclass.yaml
+          rm prioclass.yaml
+
       - name: Request TPUs (DWS)
         id: infra_request_tpus
         if: env.LLMDBENCH_CICD_TARGET == 'gke' && contains(inputs.accelerator_type, 'tpu') && inputs.tpu_chips > 0
@@ -611,6 +628,10 @@ jobs:
             completions: $VMS
             template:
               spec:
+                # The DWS placeholder is what actually acquires the chips, so it needs the
+                # priority class too; without it the request queues behind priority-0 workloads
+                # on scarce TPU capacity (llm-d/llm-d#1677).
+                priorityClassName: $LLMDBENCH_CICD_PRIORITY_CLASS
                 nodeSelector:
                   cloud.google.com/gke-flex-start: "true"
                   cloud.google.com/gke-tpu-accelerator: $ACCELERATOR
@@ -650,23 +671,6 @@ jobs:
         run: |
           # Release the chips so test can use them
           kubectl delete job tpu-request-job -n "$LLMDBENCH_CICD_NS"
-
-      - name: Create nightly PriorityClass
-        id: infra_create_nightly_prioclass
-        run: |
-          echo "Creating PriorityClass \"$LLMDBENCH_CICD_PRIORITY_CLASS\"..."
-          cat <<PRIORITY_EOF > prioclass.yaml
-          apiVersion: scheduling.k8s.io/v1
-          kind: PriorityClass
-          metadata:
-            name: $LLMDBENCH_CICD_PRIORITY_CLASS
-          value: 1000000
-          preemptionPolicy: PreemptLowerPriority
-          globalDefault: false
-          description: "High priority for nightly CI/CD llm-d workloads — preempts default-priority pods"
-          PRIORITY_EOF
-          kubectl apply -f prioclass.yaml
-          rm prioclass.yaml
 
       - name: Label node for simulated accelerators
         id: infra_label_node_for_simulated_accelerators
@@ -923,9 +927,32 @@ jobs:
             find "$LLMDBENCH_CICD_REPO_PATH/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/$LLMDBENCH_CICD_CONNECTOR/router/" -type f -name "*.yaml" -exec sed -i "s/optimized-baseline/$LLMDBENCH_CICD_SCENARIO/g" {} \;
           fi
           echo "### Setting priority class \"$LLMDBENCH_CICD_PRIORITY_CLASS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""
-          for i in vllm decode prefill; do
-            find "$LLMDBENCH_CICD_REPO_PATH/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/" -type f -name "patch-$i.yaml" -exec yq ".spec.template.spec.priorityClassName=\"$LLMDBENCH_CICD_PRIORITY_CLASS\"" -i {} \;
-            find "$LLMDBENCH_CICD_REPO_PATH/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/" -type f -name "patch-$i.yaml" -exec bash -c 'echo -n $1:; yq ".spec.template.spec.priorityClassName" $1' _ {} \;
+          # Match on the manifest's kind rather than on a patch-<name>.yaml filename: guides that ship
+          # whole resources instead of patches (e.g. wide-ep-lws, whose prefill/decode are
+          # LeaderWorkerSets) were silently skipped, so their pods ran at priority 0 and could never
+          # preempt (#1677). The pod template lives at a different path per kind.
+          find "$LLMDBENCH_CICD_REPO_PATH/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/" -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | \
+          while IFS= read -r -d '' manifest; do
+            kind=$(PC="$LLMDBENCH_CICD_PRIORITY_CLASS" yq -r 'select(documentIndex == 0) | .kind // ""' "$manifest" 2>/dev/null || echo "")
+            case "$kind" in
+              Deployment|StatefulSet|Job|DaemonSet|ReplicaSet)
+                PC="$LLMDBENCH_CICD_PRIORITY_CLASS" yq -i '.spec.template.spec.priorityClassName = env(PC)' "$manifest"
+                echo -n "$manifest ($kind): "; yq '.spec.template.spec.priorityClassName' "$manifest"
+                ;;
+              LeaderWorkerSet)
+                # workerTemplate is required; leaderTemplate is optional and must not be conjured up
+                # empty, since a leaderTemplate without containers fails admission.
+                PC="$LLMDBENCH_CICD_PRIORITY_CLASS" yq -i '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName = env(PC)' "$manifest"
+                echo -n "$manifest ($kind, workerTemplate): "; yq '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName' "$manifest"
+                if [[ $(yq '.spec.leaderWorkerTemplate.leaderTemplate // ""' "$manifest") != "" ]]; then
+                  PC="$LLMDBENCH_CICD_PRIORITY_CLASS" yq -i '.spec.leaderWorkerTemplate.leaderTemplate.spec.priorityClassName = env(PC)' "$manifest"
+                  echo -n "$manifest ($kind, leaderTemplate): "; yq '.spec.leaderWorkerTemplate.leaderTemplate.spec.priorityClassName' "$manifest"
+                fi
+                ;;
+              *)
+                continue
+                ;;
+            esac
           done
           if [[ $LLMDBENCH_CICD_DECODE_PODS != "auto" ]]; then
             echo "### Setting decode pods to \"$LLMDBENCH_CICD_DECODE_PODS\" on scenario \"$LLMDBENCH_CICD_SCENARIO\""


### PR DESCRIPTION
the PriorityClass was already getting created every night, it just wasnt making it onto the pods. three things:


the priority class step matched patch-vllm.yaml / patch-decode.yaml / patch-prefill.yaml by filename. wide-ep-lws has no patch files, its prefill.yaml and decode.yaml are LeaderWorkerSets, so 0 files matched and those pods came up at priority 0. optimized-baseline's patch-sglang.yaml, patch-trtllm.yaml and patch-vllm-gpt120b.yaml werent in that name list either. it matches on .kind now, with the pod template path picked per kind, and leaderTemplate only when the manifest already has one.


the DWS placeholder job that actually grabs the tpu chips had no priorityClassName, so it queued behind priority 0 workloads.


and the Create nightly PriorityClass step ran after Request TPUs (DWS), so the job would have referenced a class that didnt exist yet. moved it above.


tested by running the loop over copies of the real guides: wide-ep-lws 0 files before / 6 now, optimized-baseline 6 / 10, pd-disaggregation 12 / 12 unchanged, kustomization.yaml and serviceAccount.yaml untouched and no leaderTemplate created. also rendered the DWS job heredoc by hand to check it still parses.

this only makes the pods eligible to preempt, it wont help with the stockout @nicolexin mentioned.
Part of llm-d/llm-d#1677