### PR TITLE
fix(skills): correct nightly data gathering and lane scoring

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,36 +5,44 @@
 Shared CI infrastructure for the llm-d org. Contains:
 - **Reusable GitHub Actions workflows** — governance (Prow, stale, DCO) and nightly E2E testing
 - **Repo templates** — standard files for new llm-d repos
-- **Nightly E2E workflows** — reusable workflows for OpenShift, GKE, CKS platforms
+- **Nightly E2E workflows** — reusable workflows for OpenShift, GKE, GKE TPU, CKS and XPU
 - **Claude Code skills** — for diagnosing nightly failures (`.claude/skills/`)
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/reusable-nightly-e2e-openshift.yaml` | WVA nightly on OpenShift |
-| `.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml` | Helmfile guides on OpenShift |
-| `.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml` | Helmfile guides on GKE |
-| `.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml` | Helmfile guides on CKS (CoreWeave) |
+| `.github/workflows/reusable-nightly-e2e-openshift.yaml` | Nightly E2E on OpenShift |
+| `.github/workflows/reusable-nightly-e2e-gke.yaml` | Nightly E2E on GKE |
+| `.github/workflows/reusable-nightly-e2e-gke-tpu.yaml` | Nightly E2E on GKE TPU |
+| `.github/workflows/reusable-nightly-e2e-cks.yaml` | Nightly E2E on CKS (CoreWeave) |
+| `.github/workflows/reusable-nightly-e2e-xpu.yaml` | Nightly E2E on Intel XPU |
+| `.github/workflows/reusable-ci-nightly-benchmark.yaml` | Benchmark harness (also runs on its own cron) |
 | `.github/workflows/reusable-prow-commands.yaml` | Prow-style /lgtm, /approve commands |
 | `templates/repo-template/` | Standard repo scaffolding |
 
 ## Context-Safe Execution (MANDATORY)
 
-CI logs and kubectl output can be hundreds of lines. ALWAYS redirect to files:
+CI logs and kubectl output can be hundreds of lines. ALWAYS redirect to files, then analyze via
+`Agent(subagent_type='Explore')` with Grep:
 
 ```bash
-export LOG_DIR=/tmp/llm-d/nightly-rca
-mkdir -p $LOG_DIR
-
-# CI logs to file, never into conversation context
-gh run view <id> --repo <repo> --log > $LOG_DIR/<id>.log 2>&1
-# Analyze via Agent(subagent_type='Explore') with Grep
+export LOG_DIR=/tmp/llm-d/nightly/$(date -u +%F)   # date-scoped; $LOG_DIR accumulates
+export NS="$(git rev-parse --show-toplevel)/.claude/skills/nightly/scripts"
+mkdir -p "$LOG_DIR"
 ```
+
+`gh run view --log` renders every step as the literal string `UNKNOWN STEP` and re-echoes the
+env block ahead of each one, so it cannot be grepped for a named step. To get one step's real
+output, run `sh $NS/errtext.sh <repo> <run_id>`, which windows the job log on the failing step's
+timestamps from the jobs API. `.claude/skills/nightly/scripts/README.md` indexes the rest.
+`.claude/skills/nightly/report/SKILL.md` (Phase 3a) explains what each filter in `errtext.sh`
+removes and what breaks when it is dropped.
 
 ## Nightly Schedule
 
-Nightly E2E tests run across 4 platforms. See `.claude/skills/nightly/SKILL.md` for the full schedule matrix.
+Nightly E2E tests run across 5 platforms. `.claude/skills/nightly/SKILL.md` derives the schedule
+matrix from the crons rather than carrying a checked-in copy — run the query there.
 
 ## GitHub CLI
 
@@ -45,11 +53,17 @@ unset GITHUB_TOKEN && gh run list --repo llm-d/llm-d --limit 20
 
 ## Skills
 
-Use `/nightly` to triage nightly failures. It auto-routes to:
-- `nightly:infra` — auth/runner issues
-- `nightly:gpu` — GPU contention
-- `nightly:deploy` — helmfile/helm failures
-- `nightly:pods` — pod readiness timeouts
-- `nightly:test` — E2E test failures
-- `nightly:rca` — deep investigation
-- `nightly:report` — weekly trend report
+`nightly` is the only registered skill here — skill discovery scans `.claude/skills/*/SKILL.md`
+one level deep, so the sub-skills nested under it are files, not invocable skills. Use
+`/nightly` to triage; it Reads these by path as needed:
+
+| File under `.claude/skills/` | Covers |
+|---|---|
+| `nightly/scripts/` | the shell and jq both documents run; `README.md` there is the index |
+| `nightly/report/SKILL.md` | multi-day windows, real error text, streaks, weekly trend |
+| `nightly/infra/SKILL.md` | auth/runner issues |
+| `nightly/gpu/SKILL.md` | accelerator contention |
+| `nightly/deploy/SKILL.md` | helmfile/helm/kustomize failures |
+| `nightly/pods/SKILL.md` | pod readiness timeouts |
+| `nightly/test/SKILL.md` | E2E test failures |
+| `nightly/rca/SKILL.md` | deep investigation |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -2,60 +2,73 @@
 
 Claude Code skills for managing llm-d CI infrastructure and diagnosing nightly E2E failures.
 
-## Skill Tree
+## Layout
+
+`nightly` is the only registered skill here. Skill discovery scans `.claude/skills/*/SKILL.md`
+one level deep, so everything nested below that is a file to Read, not a skill to invoke — the
+`name: nightly:<x>` in their frontmatter declares an identity the loader never reads.
 
 ```
-nightly/                    # Smart router — entry point for all nightly failure analysis
-  nightly:infra             # Infrastructure/auth failures (GCP, AWS, runners)
-  nightly:gpu               # GPU contention and availability issues
-  nightly:deploy            # Deployment failures (helmfile, helm, install.sh)
-  nightly:pods              # Pod readiness timeout diagnosis
-  nightly:test              # E2E test failures (e2e-validate.sh, Go tests)
-  nightly:rca               # Full root cause analysis (deep investigation)
-  nightly:report            # Weekly trend report with success rates
+nightly/SKILL.md            # Registered skill — entry point for all nightly failure analysis
+  scripts/                  # The shell and jq both documents run; README.md there is the index
+  report/SKILL.md           # Multi-day windows, real error text, streaks, weekly trend
+  infra/SKILL.md            # Infrastructure/auth failures (GCP, AWS, runners)
+  gpu/SKILL.md              # Accelerator contention and availability issues
+  deploy/SKILL.md           # Deployment failures (helmfile, helm, kustomize)
+  pods/SKILL.md             # Pod readiness timeout diagnosis
+  test/SKILL.md             # E2E test failures (e2e-validate.sh, Go tests)
+  rca/SKILL.md              # Full root cause analysis (deep investigation)
 ```
+
+Six of the seven sub-skill files were last touched 2026-03-06 and predate the `-acc-` lane
+naming, the TPU DWS step and the XPU lanes; treat their specifics as unverified.
+`nightly/report/SKILL.md` is the current one.
 
 ## Quick Start
 
-Say any of these to Claude:
-- "check nightlies" — runs the `nightly` router, triages all failures
-- "why did wide-ep fail" — routes to the appropriate sub-skill
-- "nightly report" — generates weekly trend report
-- "triage GKE failures" — focuses on GKE platform failures
+- `/nightly` — triage the last 24 hours across the fleet
+- "why did wide-ep fail" — `/nightly`, then follow its routing to a sub-skill file
+- "nightly report" — `/nightly`, which reads `nightly/report/SKILL.md` for the weekly pass
 
 ## Architecture
 
 ### Smart Router Pattern
 
-The parent `nightly` skill gathers status from GitHub Actions, classifies failures by the step that failed, and routes to the appropriate sub-skill. This prevents wasting time on deep investigation when the fix is simple (e.g., rerunning a transient auth failure).
+The `nightly` skill gathers scheduled runs and the workflow registry from GitHub Actions,
+attributes each failure to its failed step, pulls the step's actual error text, and routes on
+that text to a sub-skill file. Routing on the step name alone is not enough: `Standup` and `Run`
+each cover several unrelated causes.
 
 ### Context-Safe Execution
 
-All skills redirect CI logs and kubectl output to files under `/tmp/llm-d/nightly-rca/` and analyze them via subagents. This prevents large log output from polluting the conversation context.
+All skills redirect CI logs and kubectl output to files under `/tmp/llm-d/nightly/<date>/` and
+analyze them via subagents. This prevents large log output from polluting the conversation
+context. The directory is date-scoped because every file in it is named after a run or job id
+and so accumulates rather than being overwritten; a stale one once padded a report with lanes
+that had not failed.
+
+### Shared Scripts
+
+`nightly/SKILL.md` and `nightly/report/SKILL.md` need most of the same shell and jq — the gap
+scan, the streak query, step attribution, the error-text extraction. Those live once in
+`nightly/scripts/` and are called as `sh $NS/<name>.sh`, rather than being copied into both
+documents as heredocs. Every copy that existed drifted: the gap scan grew a `TOO NEW` guard in
+one document and not the other, so the weekly report turned every lane added yesterday into a
+coverage gap.
 
 ### Failure Categories
 
-| Category | Sub-Skill | Typical Fix |
-|----------|-----------|-------------|
-| Auth/infra | `nightly:infra` | Rerun or rotate secret |
-| GPU contention | `nightly:gpu` | Wait/rerun or clean leaked namespaces |
-| Deploy | `nightly:deploy` | Fix chart values or rerun |
-| Pod readiness | `nightly:pods` | Check image tags, resource limits |
-| Test | `nightly:test` | Find regression commit, file issue |
-| Unknown | `nightly:rca` | Full investigation |
+| Category | File to Read | Typical Fix |
+|----------|--------------|-------------|
+| Auth/infra | `nightly/infra/SKILL.md` | Rerun or rotate secret |
+| Accelerator contention | `nightly/gpu/SKILL.md` | Wait/rerun or clean leaked namespaces |
+| Deploy | `nightly/deploy/SKILL.md` | Fix chart values or rerun |
+| Pod readiness | `nightly/pods/SKILL.md` | Check image tags, resource limits |
+| Test | `nightly/test/SKILL.md` | Find regression commit, file issue |
+| Unknown | `nightly/rca/SKILL.md` | Full investigation |
 
-## Repos Monitored
+## Repos and Workflows
 
-| Repo | Nightly Workflows |
-|------|-------------------|
-| `llm-d/llm-d` | 6 OCP + 3 GKE + 3 CKS + EC2 + XPU |
-| `llm-d/llm-d-workload-variant-autoscaler` | 1 OCP WVA |
-
-## Reusable Workflows (in this repo)
-
-| File | Platform |
-|------|----------|
-| `reusable-nightly-e2e-openshift.yaml` | OpenShift (WVA) |
-| `reusable-nightly-e2e-openshift-helmfile.yaml` | OpenShift (helmfile) |
-| `reusable-nightly-e2e-gke-helmfile.yaml` | GKE (helmfile) |
-| `reusable-nightly-e2e-cks-helmfile.yaml` | CKS/CoreWeave (helmfile) |
+Not duplicated here — these lists go stale as lanes are added and retired. See
+`nightly/SKILL.md`, which carries the monitored-repo table, the reusable-workflow table, and a
+query that derives the schedule matrix from the crons rather than from a checked-in copy.

--- a/.claude/skills/nightly/SKILL.md
+++ b/.claude/skills/nightly/SKILL.md
@@ -5,20 +5,55 @@ description: Analyze nightly E2E job failures across llm-d repos. Smart router t
 
 # Nightly E2E Failure Analysis
 
-Analyze and triage nightly E2E job failures across the llm-d org. This is the entry point — it routes to the appropriate sub-skill based on what happened.
+Analyze and triage nightly E2E job failures across the llm-d org. This is the entry point — it
+routes to the appropriate sub-skill based on what happened.
 
-## Context-Safe Execution (MANDATORY)
+**The sub-skills are files to Read, not skills to invoke.** Skill discovery scans
+`.claude/skills/*/SKILL.md`, one level deep. Every sub-skill here sits a level below that, at
+`.claude/skills/nightly/<name>/SKILL.md`, so none of them is registered and the Skill tool
+cannot resolve `nightly:report` or any of its siblings — the `name: nightly:<x>` in their
+frontmatter declares an identity the loader never reads. Open them with Read, by path. Each
+reference below gives the path for that reason.
 
-**CI logs and kubectl output can be hundreds of lines.** Always redirect to files:
+## Setup
+
+**CI logs and kubectl output can be hundreds of lines.** Everything below writes to files under
+`$LOG_DIR` and hands them to `Agent(subagent_type='Explore')` rather than pulling them into
+context. The shell and jq live in `nightly/scripts/`, shared with `nightly/report/SKILL.md`;
+`nightly/scripts/README.md` is the index.
 
 ```bash
-export LOG_DIR=/tmp/llm-d/nightly-rca
-mkdir -p $LOG_DIR
-
-# Pattern: download CI logs to file, never into context
-unset GITHUB_TOKEN && gh run view <run-id> --repo <repo> --log > $LOG_DIR/<run-id>.log 2>&1; echo "EXIT:$?"
-# On failure: use Agent(subagent_type='Explore') with Grep to find errors
+# Date-scoped. $LOG_DIR is named after run and job ids, so nothing in it is ever overwritten —
+# it accumulates, and a previous day's bodies silently padded one pass with 60 files for 26
+# lanes. A fresh directory each day removes that class of error at the root.
+export LOG_DIR=/tmp/llm-d/nightly/$(date -u +%F)
+export NS="$(git rev-parse --show-toplevel)/.claude/skills/nightly/scripts"
+mkdir -p "$LOG_DIR"
+[ -d "$NS" ] || echo "!! set NS to the scripts directory next to this file"
 ```
+
+Do not reach for `gh run view --log`. It renders **every** step as the literal string
+`UNKNOWN STEP`, and the env block ahead of each step is re-echoed in full, so a bare
+`grep -i error` returns mostly `LLMDBENCH_*` assignments and the runner's echo of the script's
+own `::error::` branches. `sh $NS/errtext.sh <repo> <run>` windows the job log on the failing
+step's timestamps from the jobs API instead. Step 4b calls it.
+
+### The session shell is zsh
+
+Every block below is POSIX sh and runs under zsh unchanged, but two zsh-only parses will bite
+anything you add:
+
+- **`$var[` is a subscript.** zsh reads `"$cand[.]y"` as an array subscript on `cand` and
+  raises `bad floating point constant`. Brace it: `"${cand}[.]y"`. Bare `$var` elsewhere is
+  fine — it is specifically a `[` directly after the name.
+- **`$var` does not word-split.** `set -- $pair` leaves `$1` holding the whole line, so any
+  loop built on it silently processes one field. Use `while IFS=... read` instead.
+
+Both fail *quietly* inside `$(...)` or ahead of a `|| continue`, producing a plausible empty
+result rather than an error you would notice. When a block returns nothing and you cannot see
+why, re-run it as `sh <<'EOS' … EOS` before believing the output. Anything under `$NS` is
+already immune: those run under `sh`, which is why the loops that used to sit inline here were
+moved there.
 
 ## When to Use
 
@@ -34,137 +69,414 @@ Follow this diagram as the workflow:
 START
   |
   v
-[1] Gather nightly run status (all repos)
+[1] Gather scheduled runs + workflow registry (all repos)
   |
   v
-[2] Any failures? ───No──> Report "All green" + exit
+[2] Any lane registered but not running? ──> propose successors, then report real gaps
+  |
+  v
+[3] Any failures? ───No──> Report "All green" + exit
   |
   Yes
   v
-[3] Classify each failure:
+[4] Attribute each failure to its failed step
   |
-  ├── Infra failure (auth, gcloud, AWS creds, runner) ──> nightly:infra
-  ├── GPU contention (insufficient GPUs)               ──> nightly:gpu
-  ├── Deploy failure (helmfile, helm, install.sh)       ──> nightly:deploy
-  ├── Pod readiness timeout                             ──> nightly:pods
-  ├── Test failure (e2e-validate, make test-e2e)        ──> nightly:test
-  └── Unknown                                           ──> nightly:rca (full RCA)
+  v
+[4b] Pull the actual error text for each  (report/SKILL.md Phase 3a)
+  |
+  v
+[4c] Is each failure new or chronic?      (report/SKILL.md Phase 3b)
+  |
+  v
+[5] Classify, using the error text — not the step name alone:
+  |
+  ├── Infra failure (auth, gcloud, AWS creds, runner) ──> nightly/infra/SKILL.md
+  ├── GPU contention (insufficient GPUs)               ──> nightly/gpu/SKILL.md
+  ├── Deploy failure (helmfile, helm, install.sh)       ──> nightly/deploy/SKILL.md
+  ├── Pod readiness timeout                             ──> nightly/pods/SKILL.md
+  ├── Test failure (e2e-validate, make test-e2e)        ──> nightly/test/SKILL.md
+  └── Unknown                                           ──> nightly/rca/SKILL.md
+  |
+  v
+[6] Report, grouped by shared cause rather than by lane
 ```
+
+Steps 4b and 4c are not optional polish. Without 4b you are classifying on a step name, and
+`Standup` and `Run` each cover several unrelated causes. Without 4c you cannot tell last
+night's breakage from a lane that has been red for a month, which is usually the first thing
+the reader needs to know.
 
 ## Step 1: Gather Status
 
-```bash
-export LOG_DIR=/tmp/llm-d/nightly-rca
-mkdir -p $LOG_DIR
+Use the REST runs endpoint with `--paginate` rather than `gh run list --limit N`. Both stop at
+1000 results and exit 0 without warning, and runs come back newest-first, so what you lose is
+the *oldest* days. `llm-d/llm-d` alone exceeds the cap inside a week; the 1-day window this
+skill uses stays well under it. For anything longer, use `sh $NS/fetch-window.sh`, which fetches
+one day per query and checks each day's count against the server's `total_count`
+(`.claude/skills/nightly/report/SKILL.md` Phase 0 explains it).
 
-# Get all nightly/e2e runs from last 24h across key repos
-for repo in llm-d/llm-d llm-d/llm-d-workload-variant-autoscaler; do
-  unset GITHUB_TOKEN && gh run list --repo "$repo" --limit 50 \
-    --json workflowName,status,conclusion,startedAt,databaseId,url \
-    | jq '[.[] | select(
-        (.workflowName | test("[Nn]ightly|[Ee]2[Ee]")) and
-        (.startedAt > (now - 86400 | strftime("%Y-%m-%dT%H:%M:%SZ")))
-      )]' > "$LOG_DIR/${repo##*/}-runs.json"
+`event=schedule` and `created` are applied server-side. Filter lanes on `.path`. The
+`consolidate-status-*` workflows are named `Past Status - … E2E (…)`, so a name regex of
+`[Nn]ightly|[Ee]2[Ee]` matches them and roughly doubles the apparent fleet.
+
+```bash
+# `created>=<a bare date>` spans two nights (all of yesterday's runs plus today's), so
+# every daily lane appears twice and the failure list doubles. A rolling 24-hour
+# timestamp catches each lane's latest scheduled run once.
+export SINCE=$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+               || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+
+# Bookkeeping and housekeeping crons. Everything else scheduled is treated as a lane,
+# so newly added nightlies show up without editing this list.
+export EXCLUDE_RE='prow-pr-automerge|stale[.]yaml|consolidate-status-|slash-test-nightly-cleanup'
+
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  slug=${repo##*/}
+  # NOTE: --slurp cannot be combined with --jq; pipe to a separate jq.
+  unset GITHUB_TOKEN && gh api \
+    "repos/$repo/actions/runs?event=schedule&created=%3E%3D$SINCE&per_page=100" \
+    --paginate --slurp \
+    | jq --arg ex "$EXCLUDE_RE" '[.[].workflow_runs[]
+        | select(.path | test($ex) | not)
+        | {id, name, path, workflow_id, event, conclusion, status, run_started_at, html_url}]' \
+    > "$LOG_DIR/$slug-runs.json"
+
+  # Registry of every workflow the repo has, including ones producing no runs.
+  # created_at is carried for the TOO NEW guard in Step 2: a lane added hours ago has not
+  # reached its first cron yet and must not be reported as one that never ran.
+  unset GITHUB_TOKEN && gh api "repos/$repo/actions/workflows?per_page=100" --paginate --slurp \
+    | jq '[.[].workflows[] | {id, name, path, state, created: (.created_at | split("T")[0])}]' \
+    > "$LOG_DIR/$slug-workflows.json"
+
+  # Workflow files present on the default branch, to tell "deleted" from "not firing".
+  unset GITHUB_TOKEN && gh api "repos/$repo/contents/.github/workflows?per_page=100" \
+    --paginate --slurp | jq '[.[][] | .path]' > "$LOG_DIR/$slug-files.json"
+
+  echo "$slug: $(jq length $LOG_DIR/$slug-runs.json) scheduled runs since $SINCE"
 done
 ```
 
-## Step 2: Identify Failures
+## Step 2: Coverage Gaps
+
+A lane that stops running is invisible to any check that starts from a list of runs. It reads
+as "not failing" while testing nothing. `gaps.sh` anti-joins the registry against the runs to
+find them, then puts a verdict on each: it needs `$EXCLUDE_RE` and the three JSON files Step 1
+wrote.
 
 ```bash
-# Extract failures
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  sh $NS/gaps.sh "$repo"
+  echo "== ${repo##*/}"; column -t -s$'\t' "$LOG_DIR/${repo##*/}-gap-report.tsv"
+done
+```
+
+Most zero-run workflows are ordinary PR or push workflows, so the script keeps only the ones
+that are actually scheduled — checking the file on the default branch for a `schedule:` key
+when the API reports no scheduled run. That check is required, not optional: the
+`reusable-nightly-e2e-*.yaml` workflows in this repo are `workflow_call:`-only and never
+produce runs of their own, so without it every one of them is reported as a missing nightly.
+
+Each verdict has a different fix. `STALE` and `NEVER RAN` mean checking the trigger — note that
+scheduled workflows only fire from the default branch. `DISABLED` is often GitHub's inactivity
+auto-off rather than anyone's decision. `TOO NEW` is not a gap; it is a lane waiting for its
+first cron, and it resolves itself. `LOOKUP FAILED` is not a verdict about the lane — the
+last-scheduled-run call did not return, so nothing is known. Re-run those rows; do not let them
+stand as gaps.
+
+### Renames are the common case — check for a successor before reporting a gap
+
+`REMOVED` almost always means renamed, not deleted. The anti-join above cannot see that: the
+old path stops appearing in runs, the new path is a different row that is running fine, and
+nothing links them. Reported raw, a single naming migration reads as a fleet of lost lanes.
+
+`successor.awk` matches on token overlap rather than a prefix. Lanes moved to the `-acc-`
+convention both gained and dropped tokens — `wide-ep-lws-gke` became
+`wide-ep-lws-gke-acc-gpu-vllm-x`, but `tiered-prefix-cache-cpu-offloading-gke` became
+`tiered-prefix-cache-gke-cpu-gpu-vllm-native`, which shares no usable prefix.
+
+Candidates come from `$slug-files.json` filtered by `$EXCLUDE_RE`. Unfiltered, the
+`consolidate-status-<lane>` bookkeeping workflows shadow every real lane: they carry the whole
+lane name plus two tokens, so they win the overlap and every row proposes a successor that
+tests nothing.
+
+```bash
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  slug=${repo##*/}
+  [ -s "$LOG_DIR/$slug-gap-report.tsv" ] || continue
+  jq -r --arg ex "$EXCLUDE_RE" '.[] | select(test($ex) | not)
+    | split("/") | last | sub("[.]ya?ml$";"")' "$LOG_DIR/$slug-files.json" \
+    > "$LOG_DIR/$slug-current.txt"
+  jq -r '[.[].path] | unique[]' "$LOG_DIR/$slug-runs.json" > "$LOG_DIR/$slug-ranpaths.txt"
+  echo "== $slug"
+  awk -f $NS/successor.awk -v cur="$LOG_DIR/$slug-current.txt" \
+      -v ran="$LOG_DIR/$slug-ranpaths.txt" "$LOG_DIR/$slug-gap-report.tsv" \
+    | column -t -s$'\t'
+done
+```
+
+Two candidates, not one, because the top score is often a tie and the tie-break is arbitrary.
+Token overlap is blind to platform synonyms in particular: `…-cpu-offloading-ocp` scores equally
+against the `gke` and the `ibm` lane, and `ibm-` is the OpenShift-GPU prefix, so the right answer
+is the one the score cannot distinguish. Read both rows.
+
+This proposes, it does not conclude. Confirm the candidate covers the same guide *and* the same
+platform; `ran` only means it fired in the window. A lane whose successor is confirmed is not a
+coverage gap and belongs out of the gap table entirely. `NO CANDIDATE` is the row that deserves
+attention.
+
+## Step 3: Identify Failures
+
+Carry the repo on each row. Failures come from more than one repo, and a run ID looked up
+against the wrong repo returns 404 rather than an error you would notice.
+
+```bash
 for f in $LOG_DIR/*-runs.json; do
-  jq -r '.[] | select(.conclusion == "failure" or .conclusion == "startup_failure") |
-    "\(.workflowName) | \(.conclusion) | \(.startedAt) | \(.databaseId)"' "$f"
-done > $LOG_DIR/failures.txt
+  jq -r '.[] | select(.conclusion == "failure" or .conclusion == "startup_failure"
+                      or .conclusion == "timed_out")
+    | [(.html_url | capture("github.com/(?<r>[^/]+/[^/]+)/actions") | .r),
+       .id, .conclusion, (.run_started_at | split("T")[0]), .name,
+       # Column 6 is the workflow filename, carried so Step 4c does not have to look it up
+       # again. Keep the extension: .yaml, .yml and .lock.yml all occur, and the workflows
+       # API needs the real basename.
+       (.path | sub("^\\.github/workflows/";""))] | @tsv' "$f"
+done | sort > $LOG_DIR/failures.tsv
+wc -l < $LOG_DIR/failures.tsv
 ```
 
-If `failures.txt` is empty, report all green and stop.
+`cancelled` and `skipped` are absent by design — they record no verdict either way, so
+counting them as failures overstates the damage.
 
-## Step 3: Classify Each Failure
+If `failures.tsv` is empty and Step 2 found no gaps, report all green and stop.
 
-For each failed run, get the failed step:
+## Step 4: Attribute Each Failure to Its Failed Step
+
+`failed-steps.sh` attributes in parallel rather than one `gh run view` at a time, and caches
+each run's jobs response under `$LOG_DIR` so Step 4b does not fetch it again.
 
 ```bash
-RUN_ID=<from failures.txt>
-REPO=<repo>
+cut -f1,2 $LOG_DIR/failures.tsv | sh $NS/failed-steps.sh > $LOG_DIR/failed-steps.tsv
 
-unset GITHUB_TOKEN && gh run view "$RUN_ID" --repo "$REPO" --json jobs \
-  | jq -r '.jobs[] | .steps[] | select(.conclusion == "failure") | .name' \
-  > $LOG_DIR/failed-steps-$RUN_ID.txt
+join -t$'\t' <(cut -f2,5 $LOG_DIR/failures.tsv | sort) <(sort $LOG_DIR/failed-steps.tsv) \
+  | cut -f2,3 | sort -u | column -t -s$'\t'
 ```
 
-### Classification Rules
+## Step 4b: Pull the Actual Error Text
 
-| Failed Step Pattern | Category | Sub-Skill |
+A step name says where a run stopped, not why. `Standup` and `Run` each name a whole phase of
+the reusable workflow rather than one action, so several unrelated causes land under each — a
+single night has put pod-readiness timeouts, GPU starvation, a bad kustomize path and a
+CrashLoopBackOff all under `Standup`. Classifying before this step groups them wrongly.
+
+`pull.sh` runs `errtext.sh` over the failures. Read Phase 3a of
+`.claude/skills/nightly/report/SKILL.md` before changing either — it explains why
+`--allow-escape-sequences`, the `substr($1,1,19)` window and the `##[endgroup]` skip each
+matter, and each one silently returns the wrong thing if dropped.
+
+Only the newest failure per lane matters. The 24-hour window in Step 1 normally yields one
+failure per lane, but reruns repeat lanes, and a date-only window doubles the list: a bare
+`created>=<yesterday>` once returned 52 failures across 34 lanes, at one log download per
+extra row. Collapse first; when the rows are already unique this is a no-op:
+
+```bash
+# newest failure per lane name (field 5), keeping repo and run id
+sort -t$'\t' -k5,5 -k4,4r $LOG_DIR/failures.tsv \
+  | awk -F'\t' '!seen[$5]++' | sort -t$'\t' -k5,5 > $LOG_DIR/failures-latest.tsv
+```
+
+```bash
+sh $NS/pull.sh $LOG_DIR/failures-latest.tsv
+```
+
+That writes one `err-<run>.txt` per row, six at a time, and concatenates them into
+`$LOG_DIR/errtext.out`. `xargs` cannot drive it — lane names contain spaces, so `-n` splits
+mid-name and the run IDs pair with the wrong repos.
+
+It also reports how many bodies named no cause in the step window. Expect roughly a quarter:
+`Standup` emits its own `::group::`, which truncates the window on the env dump. Those rows are
+already handled — `errtext.sh` escalates to `errsig.sh` itself and marks the body
+`## NO CAUSE IN WINDOW`, so there is no second pass to run. `##[error]` is deliberately absent
+from the signature that decides this. 25 of 34 bodies carry `##[error]Process completed with
+exit code 1.` — it marks the failure without naming it, so including it would pass every
+truncated body as explained.
+
+Read each body in full rather than tailing it. A correct window is under ten lines and the
+cause is as often on the first as the last; a `tail -6` scan reported an already-solved lane
+(`cat: /opt/gh-aw/prompts/xpia.md: No such file or directory`) as unexplained.
+
+At a dozen red lanes `errtext.out` is small enough to Read directly. Past roughly 15 lanes it
+stops fitting (34 bodies came to ~60KB with the tickers already stripped), so hand the file to
+`Agent(subagent_type='Explore')` instead of pulling it into context. Ask for one line per
+`##########` section in the form `lane | run id | cause`, quoting the decisive error line
+verbatim or `NO CAUSE IN WINDOW`, followed by clusters of sections sharing one error
+signature. Tell the agent to read each body in full rather than tailing it, to skip
+`Teardown command failed` lines, and to treat `##[error]Process completed with exit code 1.`
+as naming nothing. Step 5 classifies on the verbatim quotes; 4c and the report key on the run
+ids.
+
+Two lanes stopped at the same step are the same problem only if the error text agrees.
+Conversely, identical text across unrelated platforms is the strongest signal available that
+the fault is in shared code rather than in any one cluster — say so in the report.
+
+Note also what is *not* the cause: teardown runs after the failure and logs its own errors,
+each prefixed `Teardown command failed (continuing)`. Those are noise.
+
+## Step 4c: New or Chronic?
+
+A lane that failed last night and a lane that has failed for three weeks need different
+responses, and the run list cannot tell them apart. `lifetime.sh` — the same script Phase 3b of
+`.claude/skills/nightly/report/SKILL.md` runs — answers it per lane:
+
+```bash
+# lifetime.sh wants repo, workflow file, lane — in that order. `cut` emits fields in file
+# order regardless of how -f is written, and failures.tsv holds the lane name in field 5 and
+# the file in field 6, so awk does the reorder. The file comes straight from Step 3 rather
+# than being looked up per lane against *-runs.json, which cost a jq fan-out per row and
+# resolved by display name, silently picking one when two lanes share a name.
+awk -F'\t' -v OFS='\t' '{print $1, $6, $5}' $LOG_DIR/failures.tsv | sort -u \
+  | sh $NS/lifetime.sh | column -t -s$'\t'
+```
+
+Output is `streak | last green | decisive runs | first run | lane`, worst first. Only decisive
+runs count toward the streak, matching `lanes.jq`: counting `cancelled` as a failure inflates a
+mostly-cancelled lane into the oldest breakage in the fleet, and the run count in column 3 is
+then a count of nothing.
+
+The streak counts consecutive failures back from the newest run; a lane green at the top yields
+0. The second column is when it was last green, which is what makes the number readable — "44,
+last green 2026-06-29" and "7, last green 2026-08-05" are different problems even though both
+read as "chronic".
+
+`NEVER PASSED` in that column means no success anywhere in the lane's history. Column 4 is what
+tells you whether that matters: a lane whose first run is two days ago has one decisive failure
+and reaches `NEVER PASSED` while saying nothing, whereas `64 runs since 2026-06-11, NEVER
+PASSED` is a lane that was merged broken and needs its author rather than a tracking issue.
+
+When several lanes broke on the same day, they are probably one incident. Phase 4 of
+`report/SKILL.md` clusters lanes by streak start; use it rather than eyeballing dates.
+
+## Step 5: Classify
+
+Use the error text from 4b, not the step name alone.
+
+| Failed Step Pattern | Category | Sub-skill (Read by path) |
 |---|---|---|
-| `Authenticate to Google Cloud`, `Set up gcloud`, `Configure AWS Credentials` | Infra auth | `nightly:infra` |
-| `Set up runner`, `Set up job` (startup_failure) | Runner issue | `nightly:infra` |
-| `Check GPU availability` | GPU contention | `nightly:gpu` |
-| `Deploy guide via helmfile`, `Deploy guide via custom script`, `Deploy infrastructure` | Deploy failure | `nightly:deploy` |
-| `Wait for pods to be ready`, `Wait for infrastructure` | Pod timeout | `nightly:pods` |
-| `Run E2E validation`, `Run E2E tests`, `Run WVA E2E tests` | Test failure | `nightly:test` |
-| Anything else | Unknown | `nightly:rca` |
+| `Authenticate to Google Cloud`, `Set up gcloud`, `Configure AWS Credentials` | Infra auth | `nightly/infra/SKILL.md` |
+| `Set up runner`, `Set up job` (startup_failure) | Runner issue | `nightly/infra/SKILL.md` |
+| `Check GPU availability`, `Request TPUs (DWS)` | Accelerator contention | `nightly/gpu/SKILL.md` |
+| `Deploy guide via helmfile`, `Deploy guide via custom script`, `Deploy infrastructure`, `Standup` | Deploy failure | `nightly/deploy/SKILL.md` |
+| `Wait for pods to be ready`, `Wait for infrastructure` | Pod timeout | `nightly/pods/SKILL.md` |
+| `Run E2E validation`, `Run E2E tests`, `Run WVA E2E tests` | Test failure | `nightly/test/SKILL.md` |
+| Anything else | Unknown | `nightly/rca/SKILL.md` |
 
-## Step 4: Report
+Paths are relative to `.claude/skills/`. These are files, not invocable skills — see the note
+at the top. Six of the seven have not been edited since 2026-03-06 and predate the `-acc-` lane
+naming, the TPU DWS step and the XPU lanes; treat their specifics as unverified.
 
-Create a summary table:
+A `startup_failure` with zero jobs means the run never began, so it is neither infra nor a test
+failure. Check whether the workflow file still exists on the default branch and whether it
+parses. A rename in flight produces the same symptom until the old registration ages out.
+
+## Step 6: Report
+
+Lead with the clusters, not the lane list. A reader who sees nineteen rows learns less than one
+who sees "four problems, one of them ours". Group by the shared error text from 4b, order by
+how many lanes each accounts for, and say for each whether it is new.
 
 ```markdown
 ## Nightly Status — YYYY-MM-DD
 
-| Workflow | Platform | Status | Failed Step | Category |
-|----------|----------|--------|-------------|----------|
-| Inference Scheduling | OCP | pass | — | — |
-| Wide EP LWS | OCP | FAIL | Wait for pods | pods |
-| Inference Scheduling | GKE | FAIL | Set up gcloud | infra |
+19 of 44 scheduled runs failed. Four distinct causes; nothing broke last night.
+
+### 1. Benchmark harness never completes (4 lanes, last green 2026-08-05)
+`Pods did not complete within 1200s (phases=['Running'])` — identical on OCP, CKS, AMD ROCM
+and GKE GPU, so the fault is in the shared harness, not any one cluster.
+
+| Workflow | Platform | Status | Failed step | Streak | Last green | Category |
+|----------|----------|--------|-------------|--------|------------|----------|
+| Optimized Baseline | OCP GPU | FAIL | Run | 7 | 2026-08-05 | deploy |
+| Optimized Baseline | GKE GPU | FAIL | Run | 7 | 2026-08-05 | deploy |
+
+### 2. Flow Control has never passed (1 lane, 63 runs, 0 green)
+Empty kustomize path segments (`gpu/vllm///gke`). Not a regression — the lane has been red
+since it was added.
+
+### Coverage Gaps
+
+| Lane | Verdict | Last scheduled run | Likely successor | Action |
+|------|---------|--------------------|------------------|--------|
+| nightly-e2e-sim-cks.yaml | REMOVED | 2026-07-02 | `…-cks-acc-cpu-sim-x` (3/4) | confirm, then drop the row |
+| nightly-e2e-foo-gke.yaml | STALE | 2026-06-08 | NO CANDIDATE | check the cron and the default branch |
 ```
 
-Then follow the appropriate sub-skill for each failure.
+Report `TOO NEW` lanes, if any, as a footnote rather than a table row — they are not gaps.
+A gap table where every row resolves to a confirmed successor should be reported as "no
+coverage gaps", with the renames named in one line. Reporting a rename as a gap costs the
+reader more than saying nothing.
+
+Then Read the appropriate sub-skill file for each cluster.
 
 ## Repos to Monitor
 
-| Repo | Nightly Workflows |
-|------|-------------------|
-| `llm-d/llm-d` | 6 OCP + 3 GKE + 3 CKS + EC2 + XPU callers |
-| `llm-d/llm-d-workload-variant-autoscaler` | 1 OCP WVA caller |
+| Repo | Scheduled workflows |
+|------|---------------------|
+| `llm-d/llm-d` | ~40 `nightly-e2e-*` lanes plus `nightly-build-image` |
+| `llm-d/llm-d-infra` | `nightly-org-checks`, `reusable-ci-nightly-benchmark`, `upstream-monitor.lock` |
+
+`llm-d/llm-d-workload-variant-autoscaler` has no scheduled E2E of its own. Its nightlies run
+in `llm-d/llm-d` as `nightly-e2e-workload-autoscaling-*`.
 
 ## Reusable Workflows (in this repo)
 
-| Workflow | Platform | Type |
-|----------|----------|------|
-| `reusable-nightly-e2e-openshift.yaml` | OpenShift | WVA-specific |
-| `reusable-nightly-e2e-openshift-helmfile.yaml` | OpenShift | Helmfile guides |
-| `reusable-nightly-e2e-gke-helmfile.yaml` | GKE | Helmfile guides |
-| `reusable-nightly-e2e-cks-helmfile.yaml` | CKS (CoreWeave) | Helmfile guides |
+| Workflow | Platform |
+|----------|----------|
+| `reusable-nightly-e2e-openshift.yaml` | OpenShift |
+| `reusable-nightly-e2e-gke.yaml` | GKE |
+| `reusable-nightly-e2e-gke-tpu.yaml` | GKE TPU |
+| `reusable-nightly-e2e-cks.yaml` | CKS (CoreWeave) |
+| `reusable-nightly-e2e-xpu.yaml` | Intel XPU |
+| `reusable-ci-nightly-benchmark.yaml` | Benchmark harness |
+
+The five `reusable-nightly-e2e-*.yaml` workflows are `workflow_call:`-only — their runs appear
+under the calling workflow in `llm-d/llm-d`, never under this repo.
+`reusable-ci-nightly-benchmark.yaml` also carries a `schedule:` trigger (`- cron: '0 0 * * *'`)
+alongside `workflow_call:`, so it runs in its own right here and is listed as one of this repo's
+scheduled lanes above. Look for its failures under `llm-d/llm-d-infra`.
 
 ## Schedule Matrix
 
-| Time (UTC) | OCP | GKE | CKS | EC2 | XPU |
-|------------|-----|-----|-----|-----|-----|
-| 00:00 | inference-sched | | | | |
-| 00:30 | pd-disagg | | | | |
-| 01:00 | precise-prefix | | | | |
-| 01:30 | sim-accel | | | | |
-| 02:00 | tiered-prefix | | | | |
-| 02:30 | wide-ep-lws | | | | |
-| 03:00 | | | inference-sched | | |
-| 03:30 | | | pd-disagg | | |
-| 04:00 | | | wide-ep-lws | | |
-| 05:00 | | | wva | | |
-| 05:30 | | | benchmark | | |
-| 06:00 | | | | accel-test | |
-| 06:30 | | | | pd-accel | |
-| 07:00 | | | | wide-ep-accel | |
-| 10:00 | | inference-sched | | | |
-| 10:30 | | pd-disagg | | | |
-| 11:00 | | wide-ep-lws | | | inference+pd+prefix |
+Derive it rather than reading a checked-in copy, which goes stale as lanes are added and
+retired:
 
-## Related Skills
+```bash
+unset GITHUB_TOKEN && gh api "repos/llm-d/llm-d/actions/workflows?per_page=100" --paginate --slurp \
+  | jq -r '.[].workflows[] | select(.path | test("nightly-")) | .path' \
+  | xargs -P 8 -n 1 sh -c '
+      cron=$(unset GITHUB_TOKEN; gh api "repos/llm-d/llm-d/contents/$0" \
+        -H "Accept: application/vnd.github.raw" 2>/dev/null \
+        | grep -E "^[[:space:]]*-[[:space:]]*cron:" | head -1 \
+        | tr -d "\047\"" \
+        | sed -E "s/^[[:space:]]*-[[:space:]]*cron:[[:space:]]*//; s/[[:space:]]*#.*$//")
+      [ -n "$cron" ] && printf "%s\t%s\n" "$cron" "${0##*/}"' \
+  | sort -k2,2n -k1,1n | column -t -s$'\t'   # minute hour dom mon dow, ordered by hour
+```
 
-- `nightly:infra` — Infrastructure/auth failures
-- `nightly:gpu` — GPU contention analysis
-- `nightly:deploy` — Deployment failures
-- `nightly:pods` — Pod readiness timeouts
-- `nightly:test` — E2E test failures
-- `nightly:rca` — Full root cause analysis
-- `nightly:report` — Weekly trend report
+## Related Files
+
+Read these by path. None is a registered skill — the Skill tool cannot resolve any of them, for
+the reason given at the top of this file. Paths are relative to `.claude/skills/`.
+
+| Path | Covers |
+|------|--------|
+| `nightly/scripts/` | The shell and jq every step above runs; `README.md` there is the index |
+| `nightly/report/SKILL.md` | Multi-day windows, `errtext.sh`, streak history, incident clustering, week-over-week |
+| `nightly/infra/SKILL.md` | Infrastructure/auth failures |
+| `nightly/gpu/SKILL.md` | Accelerator contention |
+| `nightly/deploy/SKILL.md` | helmfile/helm/kustomize failures |
+| `nightly/pods/SKILL.md` | Pod readiness timeouts |
+| `nightly/test/SKILL.md` | E2E test failures |
+| `nightly/rca/SKILL.md` | Full root cause analysis |
+
+`nightly/report/SKILL.md` is the one to reach for by default: this file is the daily pass, and
+anything needing more than a one-day window, real error text, or history belongs there. The
+other six were last touched 2026-03-06 and have not been checked against the current lane
+naming or the TPU and XPU platforms.

--- a/.claude/skills/nightly/report/SKILL.md
+++ b/.claude/skills/nightly/report/SKILL.md
@@ -7,11 +7,20 @@ description: Generate weekly nightly E2E trend report with failure patterns and 
 
 Generate a comprehensive weekly report of nightly E2E job health across all platforms and guides.
 
-## Context-Safe Execution (MANDATORY)
+## Setup (MANDATORY)
+
+Every phase writes its bulk output to `$LOG_DIR` rather than into context, and runs the shell
+and jq in `nightly/scripts/` — shared with the parent `nightly/SKILL.md`, indexed by
+`nightly/scripts/README.md`.
 
 ```bash
-export LOG_DIR=/tmp/llm-d/nightly-report
-mkdir -p $LOG_DIR
+# Date-scoped. Every file in $LOG_DIR is named after a run, job or repo, so nothing in it is
+# ever overwritten — it accumulates, and a previous pass's bodies silently padded one report
+# with lanes that had not failed. A fresh directory each day removes that at the root.
+export LOG_DIR=/tmp/llm-d/nightly/$(date -u +%F)
+export NS="$(git rev-parse --show-toplevel)/.claude/skills/nightly/scripts"
+mkdir -p "$LOG_DIR"
+[ -d "$NS" ] || echo "!! set NS to the scripts directory beside nightly/SKILL.md"
 ```
 
 ## When to Use
@@ -22,61 +31,522 @@ mkdir -p $LOG_DIR
 
 ## Phase 0: Gather All Data
 
-```bash
-# Get last 7 days of runs from all repos
-SINCE=$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "7 days ago" +%Y-%m-%dT%H:%M:%SZ)
+The run list alone is not enough. Collect all of:
 
-for repo in llm-d/llm-d llm-d/llm-d-workload-variant-autoscaler; do
-  unset GITHUB_TOKEN && gh run list --repo "$repo" --limit 500 \
-    --json workflowName,status,conclusion,startedAt,databaseId,url,updatedAt \
-    | jq "[.[] | select(
-        (.workflowName | test(\"[Nn]ightly|[Ee]2[Ee]\")) and
-        (.startedAt > \"$SINCE\")
-      )]" > "$LOG_DIR/${repo##*/}-runs.json"
+1. **Scheduled runs over the window**, fetched one day per query. `gh run list --limit N` and the
+   REST runs endpoint both stop at 1000 results and exit 0 without warning. Runs come back
+   newest-first, so an oversized window silently loses its oldest days and every rate below is
+   computed on a partial week — `llm-d/llm-d` alone exceeds the cap inside a week, while one day
+   stays well under it. Each day is checked against the server's own `total_count`, so a day
+   that ever does overflow raises instead of returning short.
+2. **The workflow registry**, so lanes that produced no runs stay visible.
+3. **Workflow files on the default branch**, to tell a deleted lane from a stalled one.
+
+Filter lanes on `.path`. The `consolidate-status-*` workflows are named
+`Past Status - … E2E (…)`, so a `[Nn]ightly|[Ee]2[Ee]` name regex matches them and nearly
+doubles the apparent fleet.
+
+`fetch-window.sh` does the day-by-day fetch. Phase 6 calls it again for the previous week.
+
+```bash
+export DAYS=7
+export EXCLUDE_RE='prow-pr-automerge|stale[.]yaml|consolidate-status-|slash-test-nightly-cleanup'
+
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  slug=${repo##*/}
+  sh $NS/fetch-window.sh "$repo" $((DAYS-1)) 0 "$LOG_DIR/$slug-runs.json"
+
+  # created_at is carried for the TOO NEW guard in Phase 2: a lane registered hours ago has
+  # not reached its first cron and must not be reported as one that never ran.
+  unset GITHUB_TOKEN && gh api "repos/$repo/actions/workflows?per_page=100" --paginate --slurp \
+    | jq '[.[].workflows[] | {id, name, path, state, created: (.created_at | split("T")[0])}]' \
+    > "$LOG_DIR/$slug-workflows.json"
+
+  unset GITHUB_TOKEN && gh api "repos/$repo/contents/.github/workflows?per_page=100" \
+    --paginate --slurp | jq '[.[][] | .path]' > "$LOG_DIR/$slug-files.json"
 done
 ```
 
-## Phase 1: Success Rate by Workflow
+`fetch-window.sh` compares each day's returned count against the `total_count` the server puts
+on every page, and raises rather than returning short. Checking per day catches truncation
+while it is still partial; an assertion on the window's start date would only fire once a
+*whole* day had already vanished.
+
+The remaining check is coverage. A gap in the dates means a day returned nothing at all:
 
 ```bash
-# Calculate success rate per workflow
-for f in $LOG_DIR/*-runs.json; do
-  jq -r 'group_by(.workflowName) | .[] | {
-    workflow: .[0].workflowName,
-    total: length,
-    success: [.[] | select(.conclusion == "success")] | length,
-    failure: [.[] | select(.conclusion == "failure")] | length,
-    other: [.[] | select(.conclusion != "success" and .conclusion != "failure")] | length
-  } | "\(.workflow) | \(.success)/\(.total) (\(.success * 100 / .total)%) | \(.failure) failures"' "$f"
-done > $LOG_DIR/success-rates.txt
+for slug in llm-d llm-d-infra; do
+  jq -r --arg slug "$slug" --argjson days "$DAYS" '
+    if length == 0 then "\($slug): 0 runs  !! empty — check the event filter and $DAYS"
+    else ([.[].run_started_at[0:10]] | unique) as $d
+    | "\($slug): \(length) runs, \([.[].path] | unique | length) lanes, "
+      + "\($d[0]) -> \($d[-1]), \($d | length)/\($days) days"
+      + (if ([.[].event] | unique) != ["schedule"] then "  !! non-schedule events present"
+         else "" end)
+      + (if ($d | length) < $days
+         then "  !! a day produced no scheduled run at all" else "" end)
+    end' "$LOG_DIR/$slug-runs.json"
+done
 ```
 
-## Phase 2: Failure Timeline
+Expect `7/7` for `llm-d`. A repo with weekly crons can legitimately report fewer.
+
+## Phase 1: Classify Each Lane
+
+Pass rate alone cannot separate "broke last night" from "passed early in the week and has
+been dead since". Both read 3/7. Compute the trailing failure streak alongside the rate and
+classify on both.
+
+For the denominator, exclude `cancelled` and `skipped`. They record no verdict, and counting
+them as failures reports a clean lane as 87%. Sort by `run_started_at` before taking a streak.
+
+A run still in flight has `conclusion: null`. The window always ends at "now", so this is the
+common case and every lookup that touches `.conclusion` needs a guard. `{...}[null]` raises
+`Cannot index object with null` *before* a `// "?"` fallback can apply, so the fallback that
+looks like it handles this does not. `decisive` below is already safe because `IN()` returns
+`false` on null.
 
 ```bash
-# List all failures with dates
-for f in $LOG_DIR/*-runs.json; do
-  jq -r '.[] | select(.conclusion == "failure") |
-    "\(.startedAt | split("T")[0]) | \(.workflowName) | \(.databaseId)"' "$f"
-done | sort > $LOG_DIR/failure-timeline.txt
+for slug in llm-d llm-d-infra; do
+  jq -f $NS/lanes.jq "$LOG_DIR/$slug-runs.json" > "$LOG_DIR/$slug-lanes.json"
+done
+# Both repos, and HEALTHY lanes as a count rather than a row each: on llm-d that is ~80 lanes
+# of which the majority are green, and no later phase reads a green row. The full table stays
+# in $slug-lanes.json if you need it.
+for slug in llm-d llm-d-infra; do
+  jq -r --arg s "$slug" '(map(select(.status == "HEALTHY")) | length) as $ok
+    | "\($s): \($ok) healthy of \(length) lanes",
+      (.[] | select(.status != "HEALTHY")
+       | "\(.status)\t\(.passes)/\(.decisive)\t\(.seq)\t\(.lane)")' \
+    "$LOG_DIR/$slug-lanes.json"
+done | column -t -s$'\t'
 ```
 
-## Phase 3: Failure Categorization
+`seq` is oldest to newest: `P` pass, `F` fail, `T` timeout, `X` startup failure,
+`-` cancelled, `s` skipped, `?` still running.
 
-For each failure, get the failed step:
+| Status | Meaning | What it asks for |
+|---|---|---|
+| NEW BREAK | passing until the last run or two | start here |
+| DEGRADED | red now, unreliable before | check the current failure matches the older ones |
+| CHRONIC | red for the whole window | an owner and a tracking issue; the lane validates nothing meanwhile |
+| UNRELIABLE | green on the latest run, red most other nights | the green badge is hiding the rate |
+| NO VERDICT | most runs cancelled or skipped | usually a workflow timeout or a concurrency group |
+| FLAKY | mixed, currently green | judge on rate across the window |
+| HEALTHY | no failures | — |
+
+**Every phase below selects red lanes with `select(.red)`,** the field `lanes.jq` computes as
+`$streak > 0 and $status != "NO VERDICT"`. It is a field rather than a predicate spelled out
+per phase because each phase that spelled it out was one edit away from selecting on `.streak`
+alone. A lane can be NO VERDICT and still carry a nonzero streak: seven cancellations with one
+older failure among them classifies as NO VERDICT, and its trailing streak is 1. Selecting on
+`.streak` pulls that lane into attribution, clustering and lifetime lookup, where its stale
+failure is presented as the current one. Report NO VERDICT lanes on their own, against the
+cancellation, and do not attribute a step to them.
+
+The table cannot say either of the following. Say them in the report yourself:
+
+- **How long the lane has been red.** The window is seven days, so a lane red for eight nights
+  and one red for a hundred are both CHRONIC. Phase 3b resolves this.
+- **Whether the lane can recover on its own.** A failure that leaves state behind, such as an
+  undeleted namespace or an orphaned Job, makes the next run fail the same way, so the lane
+  stays red however the underlying resource pressure changes. Call these out. They need a manual
+  cleanup rather than a rerun.
+
+## Phase 2: Coverage Gaps
+
+A lane that stopped running never appears in a run list, so it reads as "not failing" while
+testing nothing. Anti-join the registry against the runs, then keep only workflows that are
+actually scheduled. Most zero-run workflows are ordinary PR workflows, and the
+`reusable-nightly-e2e-*.yaml` workflows in `llm-d-infra` are `workflow_call:`-only and would
+otherwise all be reported as missing nightlies.
 
 ```bash
-while IFS='|' read -r date workflow run_id; do
-  run_id=$(echo "$run_id" | tr -d ' ')
-  workflow=$(echo "$workflow" | tr -d ' ')
-  REPO="llm-d/llm-d"
-  FAILED_STEP=$(unset GITHUB_TOKEN && gh run view "$run_id" --repo "$REPO" --json jobs \
-    | jq -r '.jobs[0].steps[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1)
-  echo "$date | $workflow | $FAILED_STEP | $run_id"
-done < $LOG_DIR/failure-timeline.txt > $LOG_DIR/categorized-failures.txt
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  sh $NS/gaps.sh "$repo"
+  echo "== ${repo##*/}"; column -t -s$'\t' "$LOG_DIR/${repo##*/}-gap-report.tsv"
+done
 ```
 
-## Phase 4: Generate Report
+Each verdict wants a different response. `REMOVED` needs confirmation that a replacement lane
+covers the same ground — `successor.awk` proposes one, and the parent `nightly/SKILL.md` Step 2
+shows the invocation. `STALE` means the file is on the default branch with a `schedule:` block
+that has stopped firing, so check whether the cron was edited to something that no longer
+matches, or whether the repo hit GitHub's 60-day inactivity auto-off. `DISABLED` is usually that
+same auto-off rather than a decision anyone made. `TOO NEW` is not a gap at all: the lane was
+registered within the last two days and has not reached its first cron. Report it as a footnote
+if at all. `LOOKUP FAILED` says nothing about the lane either — the last-scheduled-run call did
+not return. Re-run Phase 2 for those rows before publishing rather than letting them stand as
+gaps.
+
+`NEVER RAN` is the awkward one, because the filter above has already established the two things
+you would check first. The workflow is registered and active, its file *is* on the default
+branch, and that file *does* contain a `schedule:` key. Do not re-check those. What is still
+open is whether the cron expression is syntactically valid but matches nothing reachable,
+whether the file landed within the last cron interval and has not come round yet, and whether
+the `schedule:` trigger sits under a `branches:`/`paths:` guard that never matches, which GitHub
+accepts silently. If none of those explain it, report the lane as unexplained rather than
+repeating the trigger advice.
+
+When several gaps share one `last` date, suspect a single rename rather than several
+independent losses, and check for successor lanes before writing one action item per row.
+
+## Phase 3: Attribute the Current Failures
+
+Only the latest failure per red lane matters for triage, so attribute those rather than every
+failure in the window. That is one call per red lane instead of one per failure, an order of
+magnitude fewer, and they parallelize.
+
+Derive the repo per row from the run URL rather than hardcoding it. A run ID looked up against
+the wrong repo returns 404 rather than an error you would notice.
+
+`failed-steps.sh` caches each run's jobs response under `$LOG_DIR`, so Phase 3a reuses it rather
+than fetching the same document again per lane.
+
+```bash
+for slug in llm-d llm-d-infra; do
+  jq -r '.[] | select(.red)
+    | [(.last_fail_url | capture("github.com/(?<r>[^/]+/[^/]+)/actions") | .r),
+       (.last_fail_id | tostring)] | @tsv' "$LOG_DIR/$slug-lanes.json"
+done | sh $NS/failed-steps.sh > $LOG_DIR/steps.tsv
+
+# `reduce` over `inputs` starts from {} and never sees the trailing empty line, so an all-green
+# week's empty steps.tsv yields {} with no guard needed.
+jq -Rn 'reduce (inputs | split("\t")) as $x ({}; .[$x[0]] = $x[1])' \
+  $LOG_DIR/steps.tsv > $LOG_DIR/steps.json
+```
+
+`steps.tsv` is keyed on run ID, which is not something a human triages against. Join it back to
+the lane table before printing, since the lane name is already sitting next to `last_fail_id`:
+
+```bash
+for slug in llm-d llm-d-infra; do
+  jq -r --slurpfile s $LOG_DIR/steps.json '$s[0] as $st
+    | .[] | select(.red)
+    | "\(.status)\t\(.passes)/\(.decisive)\t\($st[(.last_fail_id|tostring)] // "?")\t\(.lane)"' \
+    "$LOG_DIR/$slug-lanes.json"
+done | column -t -s$'\t'
+```
+
+### Getting the actual error text
+
+A step name only says where a run stopped. Every later phase that asks you to confirm something
+needs the real output of the failed step, and the two obvious routes do not provide it:
+
+- `gh run view <id> --log` renders **every** step as the literal string `UNKNOWN STEP`, so the
+  step name this phase just derived cannot be used to find anything in it.
+- The run-level log zip (`actions/runs/<id>/logs`) contains one file per *job*, not per step.
+
+What works is to window the job log on the failed step's timestamps, which the jobs API already
+returns. That is `errtext.sh`:
+
+```bash
+sh $NS/errtext.sh llm-d/llm-d 30377187409
+```
+
+It takes the failing job and step from `jobmeta.sh`, downloads the job log via `joblog.sh`,
+windows it, strips ANSI through `clean.sh`, and cuts the result to the step's own output. Each
+of the following silently returns the wrong thing if dropped:
+
+- **`--allow-escape-sequences` on the log fetch** (`joblog.sh`). Job logs carry ANSI colour, and
+  without the flag `gh` refuses the body and exits 1 with nothing on stdout. Sending that stderr
+  to `/dev/null` makes a download failure read as a step that produced no output, which is the
+  worst available failure mode, so `joblog.sh` keeps and reports it.
+- **`substr($1,1,19)` rather than bare `$1`.** Log lines carry sub-second precision while the
+  API bounds are whole seconds, so a direct string compare excludes every line in the final
+  second, which is the entire output of a step that fails in one second.
+- **Skip past the first `##[endgroup]`.** Ahead of it sits the runner's echo of the *script
+  source*. This is why `grep -i error` on a raw job log returns things like
+  `echo "::error::Unsupported accelerator type"`, a line of the script's own error branch.
+- **Stop at the next `##[group]`.** Otherwise the following step's preamble trails in. The
+  cost: a step that emits `::group::` in its *own* output is truncated at its first group, which
+  is what the escalation below exists for.
+- **The ANSI class in `clean.sh` is `[a-zA-Z]`, not `[m]`.** Colour codes are `m`-terminated,
+  but the smoketest ticker's erase-line sequence is `ESC[2K`, and a colour-only strip leaves a
+  literal `[2K` on every ticker line for each consumer to filter out by name.
+
+The `##[endgroup]` cut does most of the reduction — timestamp windowing alone still leaves
+hundreds of lines; the group boundaries take it to under ten:
+
+```
+Error from server (AlreadyExists): namespaces "llm-d-nightly-<guide>-gke-tpu" already exists
+job.batch/tpu-request-job unchanged        <- apply is a no-op, so no pod is created
+error: no matching resources found         <- kubectl wait then finds no pods
+```
+
+### When the window names no cause — `errsig.sh`
+
+The group filter is not an edge case on this fleet. On a recent pass it truncated 9 of 34 runs:
+the `Standup` step emits its own `::group::` around the env dump, so the window ends on the env
+block and the output tails out on `namespace/… configured` and `secret/llm-d-hf-token created`.
+Both are normal setup lines, so the result reads like a step that failed without saying
+anything.
+
+`errtext.sh` detects this itself and escalates — there is no second pass to run by hand. Before
+printing, it tests the body against the signature list below; if fewer than three substantive
+lines survive, or nothing in them matches, it prints `## NO CAUSE IN WINDOW — whole-log
+signature scan follows` and hands off to `errsig.sh`. The marker is what `pull.sh` counts to
+report the escalation rate, and it is worth reading in the output: a body carrying it was found
+by a net rather than by a window, so it is likelier to need a second look.
+
+`##[error]` is deliberately absent from that signature list, though `errsig.sh` greps for it. 25
+of 34 bodies carry `##[error]Process completed with exit code 1.` — it marks the failure without
+naming it, so treating it as a cause would pass every truncated body as explained.
+
+Read the *whole* windowed body, not its tail. When the window is correct it is usually under
+ten lines, and the cause often sits on the first — `cat: /opt/gh-aw/prompts/xpia.md: No such
+file or directory` opened the window on a lane that a `tail -6` scan reported as unexplained.
+Reserve `tail` for the untruncated raw log.
+
+Dropping the group filter does not rescue those. What follows the failure is the pipeline's
+debug collection — node capacity listings, `kubectl describe`, `kubectl get events`, and a
+second echo of the env — so the error is buried mid-log rather than at the tail.
+
+What `errsig.sh` does instead is search the whole job log for the signatures the harness and
+kubelet actually emit, and subtract the known sources of false positives. It shares
+`jobmeta.sh`, `joblog.sh` and `clean.sh` with `errtext.sh`, so on the escalation path the jobs
+response and the job log are both already on disk and no call is repeated.
+
+Four filters. Dropping any of them buries the cause:
+
+- **`::error::`, `::warning::`, `GITHUB_STEP_SUMMARY` and `LLMDBENCH_`** — the runner
+  re-echoes the script source and the whole env block ahead of every step, so without these
+  the output is the script's own error and warning branches and a wall of `LLMDBENCH_EXTRA_*`
+  assignments. This is the same trap the parent skill warns about for `gh run view --log`.
+  The `::warning::` and step-summary echoes quote the condition verbatim:
+  `echo "**Insufficient GPUs** — need $REQUIRED_GPUS…" >> $GITHUB_STEP_SUMMARY` matches the
+  `Insufficient` signature and reads like a scheduler event.
+- **The progress ticker (`⏳`)** — the smoketest wait redraws its status line every ten
+  seconds, and each redraw names every not-ready pod with states like `Unschedulable`, so one
+  failing wait matches the signature list hundreds of times. The `ESC[2K` erase-line sequence
+  that starts each redraw is already gone by this point — `clean.sh` strips it — but the hourglass
+  is ordinary text and has to be filtered by name.
+- **The `$noise` list** — teardown runs *after* the failure and logs its own errors, and the
+  pipeline's debug collection reliably emits `jobs.batch "download-model" not found`,
+  `pods "access-to-harness-data-workload-pvc" not found` and the tool-check table's
+  `oc — (optional, not found)` whatever went wrong. Note the last one is *not* covered by the
+  `Optional tool not found` term — that is a different line, and filtering one does not filter
+  the other. Each appears in 29 of 41 failing job logs. Left in, they match the
+  broad `not found` term and crowd the real cause out of the `tail`; that is what buried
+  `Failed to pull image "…llm-d-router-disagg-sidecar:v0.8.1": … not found` on the ROCM lane.
+- **The `awk` dedup on line content** — `FailedScheduling` events repeat once per pod and once
+  per collection pass. One node-capacity message across ten pods otherwise fills the whole
+  tail and pushes the actual failure out.
+
+If the tail still looks like debug output, widen the `tail` in `errsig.sh` or grep
+`$LOG_DIR/job-<job>.log` for the specific term the earlier lines hint at. `errsig.sh` is a net,
+not a parser. Two signatures worth knowing on sight, because neither appears in the windowed
+output and both arrive only via the escalation:
+
+```
+0/20 nodes are available: 13 Insufficient cpu, 3 node(s) had untolerated taint …
+      -> cluster capacity, not the guide. Expect every lane on that platform to be red.
+Failed to pull image "docker.io/lmsysorg/sglang:v0.5.16.0": … not found
+      -> a tag that does not exist. Will not clear on a rerun.
+```
+
+## Phase 3b: Lifetime Context for Red Lanes
+
+Everything so far is scoped to seven days, so every lane that is red throughout looks the same.
+They want opposite actions. A lane that regressed last month needs the change that broke it
+reverted, a lane red since spring needs a decision about whether to keep it, and a lane that has
+**never passed once** needs its author, because there is no green state to restore and a
+tracking issue will sit on it forever.
+
+Count the streak over decisive runs only, matching Phase 1; counting cancellations as failures
+here inflates a mostly-cancelled lane into the oldest breakage in the fleet.
+
+One paginated call per red lane, so roughly a dozen:
+
+```bash
+for slug in llm-d llm-d-infra; do
+  jq -r --arg r "llm-d/$slug" '.[] | select(.red) | "\($r)\t\(.file)\t\(.lane)"' \
+    "$LOG_DIR/$slug-lanes.json"
+done | sh $NS/lifetime.sh > $LOG_DIR/lifetime.tsv
+column -t -s$'\t' $LOG_DIR/lifetime.tsv   # streak | last success | decisive runs | first run | lane
+```
+
+`.file` and not `.lane` in the second column: the workflows API needs the real basename, and
+`.yaml`, `.yml` and `.lock.yml` all occur in this fleet.
+
+Runs come back newest first, so the index of the first `success` is the lifetime failure streak.
+A lane with no success anywhere reads `NEVER PASSED` in column 2. That is not a regression, so
+report those separately from CHRONIC:
+
+```bash
+awk -F'\t' '$2 == "NEVER PASSED"' $LOG_DIR/lifetime.tsv | column -t -s$'\t'
+```
+
+Check `first run` before writing any of these up. A lane merged yesterday shows one decisive run
+and a streak of 1, which satisfies the test while saying nothing. Report a never-passed lane
+only once it has had a few nights to run.
+
+Column 2 carries two other sentinels, and neither is a finding about the lane. `LOOKUP FAILED`
+means the workflows API returned nothing for that basename — a rename, or a rate limit — and
+`NO DECISIVE RUN` means every run it has ever had was cancelled or skipped. Both print a row
+rather than vanishing: an unguarded lookup used to drop the lane from the table entirely, which
+reads as "no lifetime concern" rather than "not answered".
+
+## Phase 3c: Categorize
+
+Do not invent a failure taxonomy and do not map step names to it by hand. The pipeline already
+classifies its own failures: `reusable-ci-nightly-benchmark.yaml` in `llm-d-infra` assigns every
+run a `failure_category` of `prepare`, `prereqs`, `infra`, `guide` or `benchmark`, chosen by
+which step ID failed, and the step IDs carry the category as a prefix. Generate the lookup from
+the workflow source so it stays correct as steps are renamed, added and removed:
+
+```bash
+unset GITHUB_TOKEN && gh api \
+  "repos/llm-d/llm-d-infra/contents/.github/workflows/reusable-ci-nightly-benchmark.yaml" \
+  -H "Accept: application/vnd.github.raw" > $LOG_DIR/benchmark-wf.yaml
+
+# One pass produces both things this phase needs. The category map goes to -v out=…; the step
+# ids that can fail *without* setting a category go to stdout, and are discussed below.
+awk -f $NS/bench-steps.awk -v out=$LOG_DIR/step-category.tsv $LOG_DIR/benchmark-wf.yaml \
+  | sort > $LOG_DIR/uncategorized-step-ids.txt
+jq -Rn 'reduce (inputs | split("\t")) as $x ({}; .[$x[1]] = $x[0])' \
+  $LOG_DIR/step-category.tsv > $LOG_DIR/step-category.json
+
+# Fleet-wide counts over the current failures Phase 3 attributed
+jq -r -n --slurpfile st $LOG_DIR/steps.json --slurpfile cat $LOG_DIR/step-category.json '
+  $st[0] | to_entries | map($cat[0][.value] // "uncategorized")
+  | group_by(.) | map("\(length)\t\(.[0])") | .[]' | sort -rn
+```
+
+`uncategorized` is expected. The map covers the benchmark reusable workflow, so lanes that stand
+a guide up by another route and non-benchmark lanes such as the `gh-aw` agentic workflows fall
+outside it. Report the count rather than forcing those into a bucket.
+
+Categorizing on the step *name* instead is wrong in both directions. `Request TPUs (DWS)` reads
+like accelerator contention and is `infra_request_tpus` → **infra**; the step usually dies in
+about a second on stale cluster state with no contention involved. `Standup` is `guide_standup`
+→ **guide** for every lane that fails there, which is correct but coarse, collecting capacity
+exhaustion and pod-readiness failures under one label.
+
+That coarseness is deliberate. Categories are cheap and belong in the breakdown table. Causes
+are expensive and belong in the incidents section, backed by the error text from `errtext.sh`.
+Do not try to recover causes from the category table, and do not subdivide the categories on
+guesswork to make the table look more informative than it is.
+
+As a cross-check, the badge job commits its verdict to `gh-pages` with the category in the
+commit message:
+
+```bash
+unset GITHUB_TOKEN && gh api \
+  "repos/llm-d/llm-d/commits?sha=gh-pages&since=$(date -u -v-${DAYS}d +%Y-%m-%d 2>/dev/null \
+    || date -u -d "$DAYS days ago" +%Y-%m-%d)&per_page=100" --paginate --slurp \
+  | jq -r '[.[][].commit.message] | map(capture("\\((?<m>[a-z-]+)\\)$").m)
+           | group_by(.) | map("\(length)\t\(.[0])") | .[]' | sort -rn
+```
+
+Read this as state transitions rather than one row per run. The badge is only committed when the
+JSON changes, so a lane failing the same way two nights running produces one commit. Use it to
+sanity-check the shape of the breakdown rather than to fill it.
+
+The two disagree on a known set of steps. The map above is derived from step-ID prefixes, but
+`detect_failure` tests an explicit `elif` list, and that list is a subset of the steps carrying a
+category prefix. If a step outside it fails, the pipeline emits an empty category and the badge
+reads a bare `failing` while the map here assigns a category from the prefix. An unexplained
+`failing` badge against a populated row is that gap rather than a miscount.
+
+That set changes as steps are added, which is why `bench-steps.awk` derives it above rather than
+carrying a list. It is already in `$LOG_DIR/uncategorized-step-ids.txt`:
+
+```bash
+cat $LOG_DIR/uncategorized-step-ids.txt
+```
+
+Match the step id token class as `[a-z0-9_]`. An earlier `grep` used `[a-z_]` and stopped at the
+first digit, so `prepare_skip_tpu_v7_run` was compared as `prepare_skip_tpu_v` on both sides and
+reported under a step id that does not exist. The full id is a real gap; the truncated name it
+was reported under was noise.
+
+## Phase 4: Correlate
+
+Grouping on the failed step alone over-merges. `Standup` and `Run` name a whole phase of the
+reusable workflow, so unrelated causes collect under one name. Group by step *and* by when each
+lane broke: lanes that failed at the same step starting the same night are one investigation,
+while a lane that broke last night at a step five others have failed at all week is separate.
+
+```bash
+# cluster.jq needs $steps bound, and jq has no --slurpfile equivalent for a *filter* file, so
+# the filter is composed inline around it rather than passed with -f.
+jq --slurpfile sf $LOG_DIR/steps.json \
+   '$sf[0] as $steps | '"$(cat $NS/cluster.jq)" \
+   $LOG_DIR/llm-d-lanes.json > $LOG_DIR/incidents.json
+jq -r '.[] | "\(if .incident then "INCIDENT" else "pair" end)\t\(.lanes)\t\(.step)"
+  + "\t\(.broke_on | map(. // "before window") | join(", "))"
+  + "\t\([.members[].lane] | join(", "))"' \
+  $LOG_DIR/incidents.json | column -t -s$'\t'
+```
+
+A cluster whose `broke_on` is a single date is one event and you can line it up against what
+merged that day. Several dates means the members went red on different nights, which points at
+a fault carried in state rather than a change landing. `before window` means the whole cluster
+predates the window, so take the real dates from Phase 3b.
+
+This clusters `llm-d` only. The other repo has few enough lanes to correlate by eye, but say so
+rather than letting its failures quietly skip incident analysis.
+
+Before writing a cluster up as one cause, confirm it on the error text of two of its members
+rather than on the step name: `sh $NS/errtext.sh <repo> <run_id>` on two `members[].url`
+values.
+
+Clustering fails in both directions:
+
+- **Over-merged.** Two unrelated causes share a step name. Four lanes failing at `Standup` can
+  be capacity exhaustion on one platform and pods that schedule fine then never pass a startup
+  probe on another. Confirming on error text splits these.
+- **Under-merged.** One cause spreads across lanes on different nights, so the streak window
+  puts them in separate clusters. A fault carried in per-namespace or per-cluster state poisons
+  each lane the first time *that lane* touches it, which can be days apart. The symptom is a
+  lane with a short streak whose error text matches a much older cluster at the same step.
+
+The clustering above only catches the first. List the candidates for the second explicitly,
+which are the steps whose red lanes span more than the cluster window:
+
+```bash
+jq -r --slurpfile sf $LOG_DIR/steps.json '$sf[0] as $st
+  | [ .[] | select(.red)
+      | {lane, streak, step: ($st[(.last_fail_id|tostring)] // "(unknown)")} ]
+  | group_by(.step) | map(select(length >= 2))
+  | map(select((map(.streak) | max) - (map(.streak) | min) > 2))
+  | .[] | "\(.[0].step)\t\([.[] | "\(.lane) [streak \(.streak)]"] | join(", "))"' \
+  $LOG_DIR/llm-d-lanes.json | column -t -s$'\t'
+```
+
+This is a candidate list. It will surface unrelated lanes that happen to share a step name. Resolve each one on error text. Matching signatures mean one incident
+reported once; differing signatures mean the split was right. Check a newly broken lane
+appearing next to a long-broken one first, since reporting it as an isolated new break costs
+more than the reverse.
+
+## Phase 5: Generate Report
+
+Compute the summary figures rather than estimating them from the tables above:
+
+```bash
+jq -n --slurpfile a $LOG_DIR/llm-d-lanes.json --slurpfile b $LOG_DIR/llm-d-infra-lanes.json '
+  def rate: (map(.decisive) | add // 0) as $n
+    | {runs: $n, pct: (if $n > 0 then ((map(.passes) | add) * 100 / $n | floor) else null end)};
+  ($a[0] + $b[0]) as $all
+  | { lanes:      ($all | length), llm_d: ($a[0] | length), infra: ($b[0] | length),
+      fleet:      ($all | rate),
+      ex_chronic: ($all | map(select(.status != "CHRONIC")) | rate),
+      new_break:  ($all | map(select(.status == "NEW BREAK")) | length),
+      chronic:    ($all | map(select(.status == "CHRONIC"))   | length),
+      no_verdict: ($all | map(select(.status == "NO VERDICT"))| length) }' \
+  > $LOG_DIR/summary.json
+cat $LOG_DIR/summary.json
+echo "never passed:  $(awk -F'\t' '$2 == "NEVER PASSED"' $LOG_DIR/lifetime.tsv \
+                       | wc -l | tr -d ' ')"
+# TOO NEW is a lane awaiting its first cron and LOOKUP FAILED is a call that did not return.
+# Neither is a coverage gap, and counting the rows wholesale reported both as one.
+echo "coverage gaps: $(cat $LOG_DIR/*-gap-report.tsv \
+                       | grep -cvE '^(TOO NEW|LOOKUP FAILED)')"
+```
+
+`pct` is null when no lane produced a decisive run, which is the all-green-and-all-cancelled
+case. Say so rather than printing 0%.
 
 ### Template
 
@@ -84,68 +554,162 @@ done < $LOG_DIR/failure-timeline.txt > $LOG_DIR/categorized-failures.txt
 ## Nightly E2E Report — Week of YYYY-MM-DD
 
 ### Summary
-- **Total runs**: N
-- **Pass rate**: X% (Y/N)
-- **Unique failures**: Z
+- **Lanes**: `.lanes` (`.llm_d` in llm-d, `.infra` in llm-d-infra)
+- **Decisive runs**: `.fleet.runs` — `.fleet.pct`% passed, **`.ex_chronic.pct`% excluding chronic lanes**
+- **Needs attention**: `.new_break` new breaks, `.chronic` chronic (C of which have never passed),
+  D coverage gaps
 
-### Success Rate by Workflow
+Fleet-wide pass rate is a weak signal on its own, because chronic lanes hold it down and it
+barely moves when one lane breaks. Quote it next to the rate with chronic lanes excluded. The
+second number answers whether the working part of the fleet is getting worse.
 
-| Workflow | Pass Rate | Failures | Trend |
-|----------|-----------|----------|-------|
-| Inference Scheduling (OCP) | 7/7 (100%) | 0 | stable |
-| Wide EP LWS (OCP) | 3/7 (43%) | 4 | degraded |
-| PD Disaggregation (GKE) | 5/7 (71%) | 2 | flaky |
+### Lanes Needing Attention
+
+| Lane | Status | Passed | Broke on | Sequence | Failed step | Cost | Run |
+|------|--------|--------|----------|----------|-------------|------|-----|
+| nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x | NEW BREAK | 5/7 | 2026-07-27 | `PPPPPFF` | Request TPUs (DWS) | 1h2m | <url> |
+| nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x | CHRONIC | 0/7 | before window | `FFFFFFF` | Standup | 5h1m | <url> |
+
+`Passed` is a count over decisive runs. At seven runs a week `5/7` carries information that
+`71%` throws away, and it makes the denominator visible when cancellations shrink it.
+Percentages appear only in the summary and in Phase 6, where the comparison is across weeks. Do
+not mix the two units in one table.
+
+Rates exclude cancelled and skipped runs. Sequence is oldest to newest. Cost is `fail_min` ×
+failures, roughly the cluster time this lane burnt over the window. `fail_min` is whole-run wall
+clock rather than time in the failing step, so a run whose step dies in the first second still
+pays for debug collection and teardown. Expect a lane that bails during standup to read around
+10 minutes against 40-plus for one that holds accelerators through a readiness timeout. Use the
+ratio between lanes rather than the absolute number. Flag any lane that cannot recover without
+manual cleanup, since a rerun will not clear it.
+
+### Lanes That Have Never Passed
+
+From Phase 3b, the lanes reading `NEVER PASSED` in `lifetime.tsv`. These are not regressions and
+do not belong in the chronic list. `First seen` is the `first run` column from the same file.
+
+| Lane | Runs | First seen | Note |
+|------|------|------------|------|
+| nightly-e2e-flow-control-gke-acc-gpu-vllm-x | 63 | 2026-06-11 | merged broken; needs its author |
+
+Drop any lane whose first run is within the last few days. One decisive run satisfies the
+never-passed test without meaning anything.
+
+For chronic lanes that *did* once pass, give the last-success date rather than the in-window
+streak. "Red since April" and "red since Monday" read identically at seven days.
+
+### Coverage Gaps
+
+| Lane | Verdict | Last scheduled run | Action |
+|------|---------|--------------------|--------|
+| nightly-e2e-wide-ep-lws-gke | REMOVED | 2026-06-08 | confirm a replacement lane covers this |
+| nightly-e2e-fast-model-actuation-ibm-acc-gpu-vllm-x | NEVER RAN | never | unexplained — trigger checks exhausted |
+
+Action is the standard response for the verdict. Where a gap survives those checks, say so
+instead of restating them. Gaps sharing a `last` date are usually one
+rename, so collapse them into a single row.
+
+### Lanes With No Verdict
+
+Lanes classified NO VERDICT in Phase 1, which every later phase excludes. These have no failed
+step to attribute, so report the cancellation itself.
+
+| Lane | Sequence | Note |
+|------|----------|------|
+| nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native | `-------` | cancelled every night; check the workflow timeout and concurrency group |
+
+### Probable Single Incidents
+
+One row per confirmed cause rather than per cluster. Split a cluster whose members show
+different error text, and merge clusters whose members show the same.
+
+| Cause | Step | Lanes | Broke on | Evidence |
+|-------|------|-------|----------|----------|
+| GKE accelerator capacity exhausted | Standup | 3 | before window (since 2026-06-29) | `FailedScaleUp: GCE out of resources` |
+| Stale namespace blocks TPU request | Request TPUs (DWS) | 3 | 2026-07-22, 2026-07-26 | `AlreadyExists` then `no matching resources found` |
+
+`Broke on` comes from the cluster's `broke_on`. Where it reads `before window`, give the real
+date from Phase 3b in parentheses. An incident whose members have been red since June is a
+different conversation from one that started this week.
 
 ### Failure Breakdown by Category
 
+The pipeline's own categories, from Phase 3c. Do not substitute a taxonomy of your own.
+
 | Category | Count | % of Failures |
 |----------|-------|---------------|
-| Infra/Auth | N | X% |
-| GPU Contention | N | X% |
-| Deploy | N | X% |
-| Pod Readiness | N | X% |
-| Test | N | X% |
+| prepare | N | X% |
+| prereqs | N | X% |
+| infra | N | X% |
+| guide | N | X% |
+| benchmark | N | X% |
+| uncategorized | N | X% |
 
-### Notable Patterns
-- <pattern 1: e.g., "All GKE failures are gcloud auth — likely secret rotation needed">
-- <pattern 2: e.g., "Wide EP consistently fails pod readiness — LWS scaling issue">
+State the denominator. If these counts come from the current failure per red lane, they cover
+that set rather than every failure in the window, and the two differ by roughly an order of
+magnitude. Keep the `uncategorized` row even at zero, since Phase 3c's count is part of the
+result.
 
 ### Action Items
 - [ ] <action 1>
 - [ ] <action 2>
-
-### Daily Heatmap
-
-| Day | OCP | GKE | CKS | EC2 |
-|-----|-----|-----|-----|-----|
-| Mon | 6/6 | 2/3 | — | 1/1 |
-| Tue | 5/6 | 3/3 | — | 0/1 |
-| ... | ... | ... | ... | ... |
 ```
 
-## Phase 5: Trend Analysis
+Group findings by cause rather than by lane. Say which lanes you could not explain, and treat a
+step name as an explanation only if you have the error text behind it.
 
-Compare this week vs previous:
+## Phase 6: Week-over-Week
+
+Both windows are `$DAYS` long and they do not overlap: the current one covers days `DAYS-1`
+through `0` and the previous one covers `2*DAYS-1` through `DAYS`. Unequal windows would put a
+`/7` denominator next to a `/8` one and read the difference as a change in health.
 
 ```bash
-# Get previous week's data
-PREV_SINCE=$(date -u -v-14d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "14 days ago" +%Y-%m-%dT%H:%M:%SZ)
-PREV_UNTIL=$SINCE
-
-for repo in llm-d/llm-d llm-d/llm-d-workload-variant-autoscaler; do
-  unset GITHUB_TOKEN && gh run list --repo "$repo" --limit 500 \
-    --json workflowName,conclusion,startedAt \
-    | jq "[.[] | select(
-        (.workflowName | test(\"[Nn]ightly|[Ee]2[Ee]\")) and
-        (.startedAt > \"$PREV_SINCE\") and
-        (.startedAt < \"$PREV_UNTIL\")
-      )]" > "$LOG_DIR/${repo##*/}-prev-week.json"
+for repo in llm-d/llm-d llm-d/llm-d-infra; do
+  slug=${repo##*/}
+  sh $NS/fetch-window.sh "$repo" $((2*DAYS-1)) $DAYS "$LOG_DIR/$slug-prev-runs.json"
+  jq -f $NS/lanes.jq "$LOG_DIR/$slug-prev-runs.json" > "$LOG_DIR/$slug-prev-lanes.json"
 done
+
+# Confirm the two windows are the same length and disjoint before comparing them.
+jq -n --slurpfile p $LOG_DIR/llm-d-prev-runs.json --slurpfile c $LOG_DIR/llm-d-runs.json '
+  ([$p[0][].run_started_at[0:10]] | unique) as $a
+  | ([$c[0][].run_started_at[0:10]] | unique) as $b
+  | {prev: "\($a[0]) -> \($a[-1])", days_prev: ($a|length),
+     cur:  "\($b[0]) -> \($b[-1])", days_cur:  ($b|length),
+     overlap: [$a[] | select(IN($b[]))]}'
+
+# Per-lane rate delta against last week
+jq -rn --slurpfile now $LOG_DIR/llm-d-lanes.json --slurpfile prev $LOG_DIR/llm-d-prev-lanes.json '
+  ($prev[0] | map({key: .lane, value: .rate}) | from_entries) as $p
+  | $now[0]
+  | map(select($p[.lane] != null and (.rate - $p[.lane] | fabs) >= 15)
+        | {lane, was: $p[.lane], now: .rate, status})
+  | sort_by(.now - .was)
+  | .[] | "\(.lane)\t\(.was)% -> \(.now)%\t\(.status)"' \
+  | column -t -s$'\t'
 ```
 
-Trends: improving, stable, degraded, new failure
+Also compare the lane sets, in both directions:
 
-## Related Skills
+```bash
+jq -n --slurpfile now $LOG_DIR/llm-d-lanes.json --slurpfile prev $LOG_DIR/llm-d-prev-lanes.json '
+  ($prev[0] | map(.lane)) as $p
+  | {appeared:    ($now[0]  | map(select(.lane | IN($p[])            | not))
+                            | map({lane, status, rate})),
+     disappeared: ($prev[0] | map(select(.lane | IN($now[0][].lane)  | not)) | map(.lane))}'
+```
 
-- `nightly` — Parent router (for individual failure triage)
-- `nightly:rca` — Deep dive on specific failures flagged in report
+A lane that **disappeared** is a coverage gap that Phase 2 will confirm. A lane that
+**appeared** matters too and is easy to miss: one merged in a broken state starts inflating the
+chronic count immediately while looking like ordinary background red. Check the status of every
+lane in `appeared`. A new lane that has never passed belongs with the never-passed lanes from
+Phase 3b rather than with the chronic ones.
+
+## Related Files
+
+Read these by path; none is a registered skill. Paths are relative to `.claude/skills/`.
+
+- `nightly/scripts/` — the shell and jq every phase above runs; `README.md` there is the index
+- `nightly/SKILL.md` — parent router, for triaging a single night rather than a week
+- `nightly/rca/SKILL.md` — deep dive on specific failures flagged in this report

--- a/.claude/skills/nightly/scripts/README.md
+++ b/.claude/skills/nightly/scripts/README.md
@@ -1,0 +1,47 @@
+# nightly scripts
+
+The shell and jq that `nightly/SKILL.md` and `nightly/report/SKILL.md` run. They live here as
+files rather than as heredocs inside the two documents, because both documents need most of
+them and a heredoc can only be copied, not shared. Every copy that existed drifted: the gap
+scan grew a `TOO NEW` guard in one document and not the other, so the weekly report turned
+every lane added yesterday into a coverage gap.
+
+Both documents export the same two variables before calling anything here:
+
+```bash
+export LOG_DIR=/tmp/llm-d/nightly/$(date -u +%F)   # per-day, so yesterday's artifacts cannot leak in
+export NS="$(git rev-parse --show-toplevel)/.claude/skills/nightly/scripts"
+mkdir -p "$LOG_DIR"
+```
+
+Everything is POSIX `sh`, invoked as `sh $NS/<name>.sh`, and writes its bulk output to
+`$LOG_DIR` rather than to stdout. `awk`/`jq` files are passed with `-f`.
+
+| File | Takes | Gives |
+|---|---|---|
+| `fetch-window.sh` | repo, oldest-days-ago, newest-days-ago, outfile | scheduled runs for the window, one API query per day |
+| `gaps.sh` | repo | `$slug-gaps.json`, `$slug-gap-report.tsv` — registered lanes producing no runs, with a verdict each |
+| `successor.awk` | `cur=`, `ran=`, gap report on argv | a proposed replacement lane per gap row, by token overlap |
+| `jobmeta.sh` | repo, run id | `job_id⇥step_start⇥step_end⇥step_name` for the first failing step; caches the jobs response |
+| `joblog.sh` | repo, job id | ensures `$LOG_DIR/job-<job>.log`; a concluded job's log is immutable, so it downloads once |
+| `clean.sh` | a job log on stdin | the same log with ANSI stripped and the timestamp column cut |
+| `errtext.sh` | repo, run id | the failing step's real output, escalating to `errsig.sh` when that window names no cause |
+| `errsig.sh` | repo, run id | whole-job-log grep for error signatures, minus the known false positives |
+| `bench-steps.awk` | `out=`, benchmark workflow on argv | the step-id→category map to `out=`, and to stdout the ids that set no category |
+| `failed-steps.sh` | `repo⇥run` on stdin | `run⇥step` TSV, 8 at a time |
+| `pull.sh` | TSV whose fields 1, 2 and 5 are repo, run id, lane | one `err-<run>.txt` body per row, 6 at a time |
+| `lifetime.sh` | `repo⇥file⇥lane` on stdin | lifetime streak, last green, decisive runs, first run, lane — `NEVER PASSED`, `NO DECISIVE RUN` or `LOOKUP FAILED` in column 2 where there is no green |
+| `lanes.jq` | a window of runs | one classified row per lane |
+| `cluster.jq` | `$steps` + lane rows | red lanes grouped into probable single incidents |
+
+The scripts that fan out over a TSV feed `xargs` one NUL-delimited *record* and split the fields
+inside with `cut`, rather than letting `xargs -n <fields>` do the splitting. `xargs` splits on any
+whitespace, so a single field containing a space — a lane's display name, "Nightly - Optimized
+Baseline E2E (GKE GPU)" — shifts every field of that row and of every row batched after it. That
+failed loudly once, only because the stray words were not valid repo names; the general case is
+silently misaligned output. `pull.sh` avoids `xargs` altogether for the same reason.
+
+The two documents explain why each script does what it does. The comments in the scripts cover
+only what would be unsafe to change without reading that prose. Read `nightly/report/SKILL.md`
+Phase 3a before touching `errtext.sh` or `errsig.sh`. Each filter in them removes a specific
+kind of noise, and removing a filter drops output without raising an error.

--- a/.claude/skills/nightly/scripts/bench-steps.awk
+++ b/.claude/skills/nightly/scripts/bench-steps.awk
@@ -1,0 +1,54 @@
+# usage: awk -f bench-steps.awk -v out=<category tsv> reusable-ci-nightly-benchmark.yaml | sort
+#
+# One pass over the benchmark workflow, producing both things Phase 3c needs:
+#   $out    <category>\t<step name>, for every step whose id carries a category prefix
+#   stdout  step ids that can fail *without* setting a category
+#
+# The pipeline classifies its own failures — do not invent a taxonomy and do not map step names
+# to one by hand. reusable-ci-nightly-benchmark.yaml assigns every run a failure_category of
+# prepare, prereqs, infra, guide or benchmark, chosen by which step id failed, and the step ids
+# carry the category as a prefix. Deriving the map from the source keeps it correct as steps
+# are renamed, added and removed.
+#
+# The second output exists because the two disagree on a known set of steps. The map is derived
+# from id prefixes, but `detect_failure` tests an explicit elif list, and that list is a subset
+# of the steps carrying a prefix. If a step outside it fails, the pipeline emits an empty
+# category and the badge reads a bare `failing` while the map here assigns one from the prefix.
+# An unexplained `failing` badge against a populated row is that gap rather than a miscount.
+
+BEGIN { if (out == "") { bad = 1; print "usage: -v out=<file>" > "/dev/stderr"; exit 2 } }
+
+# Step entries sit at six spaces. Nested `- name:` keys inside `with:` and the matrix sit deeper
+# and are not steps, so the match has to anchor on the indent. The END guard below fires if a
+# reformat ever breaks that assumption.
+/^      - name:/ { n = $0; sub(/^ *- name: */, "", n); nname++; indetect = 0 }
+
+# `id:` needs no indent anchor: every id in the file is a step id, and the prefix test below
+# discards anything whose first token is not a category.
+/^[[:space:]]+id: / {
+  id = $2; allid[id] = 1; nid++
+  if (id ~ /^detect_/) indetect = 1
+  split(id, a, "_"); c = a[1]
+  sub(/^prereq$/, "prereqs", c)          # both prereq_ and prereqs_ land on prereqs
+  if (c ~ /^(prepare|prereqs|infra|guide|benchmark)$/) { print c "\t" n > out; ncat++ }
+}
+
+# Everything from the detect_ step to the next step entry is the elif chain. The class is
+# [a-z0-9_], not [a-z_]: the grep this replaced stopped at the first digit, so
+# prepare_skip_tpu_v7_run was compared as `prepare_skip_tpu_v` on both sides and reported under
+# a step id that does not exist.
+indetect {
+  s = $0
+  while (match(s, /steps\.[a-z0-9_]+\./)) {
+    elif[substr(s, RSTART + 6, RLENGTH - 7)] = 1
+    s = substr(s, RSTART + RLENGTH)
+  }
+}
+
+END {
+  if (bad) exit 2
+  if (nid + 0 == 0 || ncat + 0 == 0)
+    print "!! parsed " nid + 0 " ids and " nname + 0 " step names but mapped " ncat + 0 \
+          " — check the indentation assumptions against the file" > "/dev/stderr"
+  for (i in allid) if (!(i in elif) && i != "detect_failure") print i
+}

--- a/.claude/skills/nightly/scripts/clean.sh
+++ b/.claude/skills/nightly/scripts/clean.sh
@@ -1,0 +1,6 @@
+# usage: … | sh clean.sh — strips ANSI sequences and the runner's timestamp column
+# The class is [a-zA-Z], not [m]. A colour code is m-terminated, but the smoketest progress
+# ticker redraws with ESC[2K (erase line), and a sed that only removes colour leaves `[2K`
+# embedded in the text — where it has to be filtered by name in every consumer, and was, in
+# three places that each had to be kept in step. Terminating on any final byte removes both.
+sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | cut -c30-

--- a/.claude/skills/nightly/scripts/cluster.jq
+++ b/.claude/skills/nightly/scripts/cluster.jq
@@ -1,0 +1,29 @@
+# usage: jq --slurpfile sf $LOG_DIR/steps.json '$sf[0] as $steps | '"$(cat cluster.jq)" lanes.json
+#
+# Grouping on the failed step alone over-merges: Standup and Run each name a whole phase of the
+# reusable workflow, so unrelated causes collect under one name. Group by step *and* by when
+# each lane broke.
+#
+# Greedy sweep over lanes sorted by streak: extend a cluster while the next lane broke within
+# 2 runs of the cluster's start, otherwise begin a new cluster.
+def cluster:
+  sort_by(.streak)
+  | reduce .[] as $l ([];
+      if (length > 0) and (($l.streak - .[-1][0].streak) <= 2)
+      then .[0:-1] + [ .[-1] + [$l] ]
+      else . + [ [$l] ] end);
+
+$steps as $s
+| [ .[] | select(.red)
+    | . + {step: ($s[(.last_fail_id | tostring)] // "(unknown)")} ]
+| group_by(.step) | map(cluster) | (add // [])   # add on [] is null; an all-green week is valid
+| map(select(length >= 2))
+| sort_by(-length)
+| map({ step:        .[0].step,
+        lanes:       length,
+        incident:    (length >= 3),   # 3+ lanes breaking together: investigate once
+        # Dates rather than "N runs ago". If the members share one date it is a single event;
+        # if they are staggered, suspect a fault carried in state rather than a change landing.
+        broke_on:    ([.[].broke_on] | unique | sort),
+        # URLs, because confirming a cluster takes two members on error text, not step name.
+        members:     [.[] | {lane, url: .last_fail_url}] })

--- a/.claude/skills/nightly/scripts/errsig.sh
+++ b/.claude/skills/nightly/scripts/errsig.sh
@@ -1,0 +1,27 @@
+# usage: sh errsig.sh <owner/repo> <run_id> — greps the whole failing job log for real errors
+# errtext.sh calls this itself when its window names no cause; call it directly only to widen
+# an answer you already have.
+repo=$1; run=$2
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+: "${NS:?export NS to this scripts directory before calling this script}"
+
+meta=$(sh "$NS/jobmeta.sh" "$repo" "$run") || exit 1
+job=$(printf '%s' "$meta" | cut -f1)
+[ -n "$job" ] || { echo "!! no failing step on run $run"; exit 1; }
+sh "$NS/joblog.sh" "$repo" "$job" || exit 1
+
+# Post-failure debug collection, present on ~70% of failing jobs regardless of cause.
+noise='::error::|LLMDBENCH_|Teardown command failed|Optional tool not found'
+# The tool-check table renders as `  oc  —  (optional, not found)`, which shares no substring
+# with "Optional tool not found" above and so survives it. It matches the broad `not found`
+# term and heads the tail on any lane where `oc` is absent.
+noise="$noise"'|\(optional, not found\)'
+noise="$noise"'|jobs.batch "download-model" not found'
+noise="$noise"'|pods "access-to-harness-data-workload-pvc" not found'
+noise="$noise"'|::warning::|GITHUB_STEP_SUMMARY|⏳'
+
+sh "$NS/clean.sh" < "$LOG_DIR/job-$job.log" \
+  | grep -nE '❌|FAILED -|\* Error:|^error:|^Error|##\[error\]|FailedScheduling|Unschedulable|Insufficient|ErrImagePull|ImagePullBackOff|CrashLoopBackOff|BackOff|No such file|not found|denied' \
+  | grep -vE "$noise" \
+  | awk -F: '{k=$0; sub(/^[0-9]+:/,"",k); if (!seen[k]++) print}' \
+  | tail -20

--- a/.claude/skills/nightly/scripts/errtext.sh
+++ b/.claude/skills/nightly/scripts/errtext.sh
@@ -1,0 +1,58 @@
+# usage: sh errtext.sh <owner/repo> <run_id> — prints the failing step's actual output
+#
+# Windows the job log on the failed step's timestamps, which the jobs API already returns.
+# The two obvious routes do not work: `gh run view <id> --log` renders every step as the
+# literal string UNKNOWN STEP, and the run-level log zip holds one file per *job*, not per
+# step. See nightly/report/SKILL.md Phase 3a — every filter below drops silently.
+repo=$1; run=$2
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+: "${NS:?export NS to this scripts directory before calling this script}"
+
+meta=$(sh "$NS/jobmeta.sh" "$repo" "$run") || exit 1
+[ -n "$meta" ] || { echo "!! no failing job/step on run $run"; exit 1; }
+job=$(printf '%s' "$meta" | cut -f1); a=$(printf '%s' "$meta" | cut -f2)
+b=$(printf '%s' "$meta" | cut -f3);   step=$(printf '%s' "$meta" | cut -f4)
+sh "$NS/joblog.sh" "$repo" "$job" || exit 1
+
+echo "== $step  ($a -> $b) =="
+# substr($1,1,19), not bare $1: log lines carry sub-second precision while the API bounds are
+# whole seconds, so a direct string compare excludes every line in the final second — which is
+# the entire output of a step that fails in one second.
+#
+# Then skip past the first ##[endgroup] and stop at the next ##[group]. Ahead of the endgroup
+# sits the runner's echo of the *script source*, which is why `grep -i error` on a raw job log
+# returns things like `echo "::error::Unsupported accelerator type"`. Without the stop the
+# following step's preamble trails in. Timestamp windowing alone still leaves hundreds of
+# lines; the group boundaries take it to under ten.
+#
+# ⏳ is the smoketest progress ticker. It redraws every ten seconds, so on any lane that failed
+# during a wait it owns the whole body and the cause never makes it in. clean.sh has already
+# removed the ESC[2K that goes with it.
+body=$(awk -v a="$a" -v b="$b" 'substr($1,1,19) >= a && substr($1,1,19) <= b' \
+         "$LOG_DIR/job-$job.log" \
+       | sh "$NS/clean.sh" \
+       | awk 'f && /##\[group\]/{exit} f; /##\[endgroup\]/{f=1}' \
+       | grep -v '⏳')
+
+# The stop-at-##[group] clause is not an edge case on this fleet: `Standup` emits its own
+# ::group:: around the env dump, so the window ends on the env block and tails out on
+# `namespace/… configured` and `secret/llm-d-hf-token created` — normal setup lines that read
+# like a step which failed without saying anything. That truncated 9 of 34 runs on one pass.
+# Escalating here rather than leaving it to the caller: every caller wants the same answer, and
+# the two that existed had to keep their copies of this signature list in step.
+#
+# ##[error] is deliberately absent. 25 of 34 bodies carry `##[error]Process completed with exit
+# code 1.`, which marks the failure without naming it, so including it passes every truncated
+# body as explained.
+sig='❌|FAILED -|\* Error:|^error:|^Error|FailedScheduling|Unschedulable|Insufficient'
+sig="$sig"'|ErrImagePull|CrashLoopBackOff|BackOff|No such file|not found|timed out|did not become'
+n=$(printf '%s\n' "$body" \
+    | grep -cvE '^[[:space:]]*$|^namespace/|^secret/|^##\[endgroup\]')
+
+if [ "$n" -lt 3 ] || ! printf '%s\n' "$body" | grep -qE "$sig"; then
+  # Grep for this marker to count how much of a pass fell back; expect roughly a quarter.
+  echo "## NO CAUSE IN WINDOW — whole-log signature scan follows"
+  sh "$NS/errsig.sh" "$repo" "$run"
+else
+  printf '%s\n' "$body"
+fi

--- a/.claude/skills/nightly/scripts/failed-steps.sh
+++ b/.claude/skills/nightly/scripts/failed-steps.sh
@@ -1,0 +1,9 @@
+# usage: printf '<owner/repo>\t<run_id>\n' … | sh failed-steps.sh   ->  <run_id>\t<step name>
+# One row per input run, always: a run whose jobs API says nothing still needs a row, or the
+# join back onto the lane table drops the lane silently.
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+: "${NS:?export NS to this scripts directory before calling this script}"
+export NS LOG_DIR
+xargs -P 8 -n 2 sh -c '
+    step=$(sh "$NS/jobmeta.sh" "$0" "$1" 2>/dev/null | cut -f4)
+    printf "%s\t%s\n" "$1" "${step:-(jobs unavailable)}"'

--- a/.claude/skills/nightly/scripts/fetch-window.sh
+++ b/.claude/skills/nightly/scripts/fetch-window.sh
@@ -1,0 +1,34 @@
+# usage: sh fetch-window.sh <owner/repo> <oldest-days-ago> <newest-days-ago> <outfile>
+#
+# One query per day. `gh run list --limit N` and the REST runs endpoint both stop at 1000
+# results and exit 0 without warning, and runs come back newest-first, so an oversized window
+# silently loses its *oldest* days — llm-d/llm-d alone exceeds the cap inside a week, while one
+# day stays well under it.
+repo=$1; from=$2; to=$3; out=$4
+# jq's test("") matches every string, so an unset filter silently excludes every run.
+: "${EXCLUDE_RE:?export EXCLUDE_RE before calling this script}"
+unset GITHUB_TOKEN
+tmp=$(mktemp -d); i=$from
+while [ "$i" -ge "$to" ]; do
+  day=$(date -u -v-${i}d +%Y-%m-%d 2>/dev/null || date -u -d "$i days ago" +%Y-%m-%d)
+  # `created=A..B` is inclusive at both ends, so A==B is a single day.
+  # NOTE: --slurp cannot be combined with --jq; pipe to a separate jq.
+  #
+  # Every page carries the server's own total_count, so the truncation check is free — a
+  # separate per_page=1 probe doubled the call count for a number already in hand. Checking
+  # each day against it catches truncation while it is still partial; an assertion on the
+  # window's start date would only fire once a *whole* day had already vanished.
+  gh api "repos/$repo/actions/runs?event=schedule&created=$day..$day&per_page=100" \
+    --paginate --slurp \
+    | jq --arg day "$day" '(.[0].total_count // 0) as $want
+        | [.[].workflow_runs[]]
+        | if length < $want
+          then error("\($day): \(length) of \($want) runs returned — one day now exceeds the 1000 cap; split by hour")
+          else . end' > "$tmp/$day.json" || { echo "!! fetch failed for $day" >&2; exit 1; }
+  i=$((i-1))
+done
+jq -s --arg ex "$EXCLUDE_RE" 'add
+  | map(select(.path | test($ex) | not))
+  | map({id, name, path, workflow_id, event, conclusion,
+         run_started_at, updated_at, html_url})' "$tmp"/*.json > "$out"
+rm -rf "$tmp"

--- a/.claude/skills/nightly/scripts/gaps.sh
+++ b/.claude/skills/nightly/scripts/gaps.sh
@@ -1,0 +1,79 @@
+# usage: sh gaps.sh <owner/repo>
+# Reads  $LOG_DIR/<slug>-{workflows,runs,files}.json   (workflows must carry `created`)
+# Writes $LOG_DIR/<slug>-gaps.json        — registered lanes that produced no run
+#        $LOG_DIR/<slug>-gap-report.tsv   — verdict \t last scheduled run \t state \t lane
+#
+# A lane that stops running is invisible to any check that starts from a list of runs: it reads
+# as "not failing" while testing nothing. Anti-join the registry against the runs to find them.
+repo=$1; slug=${repo##*/}
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+# jq's test("") matches every string, so an unset filter silently excludes every run — and an
+# empty gap table then reads as a clean fleet.
+: "${EXCLUDE_RE:?export EXCLUDE_RE before calling this script}"
+
+jq -n --slurpfile wf "$LOG_DIR/$slug-workflows.json" \
+      --slurpfile runs "$LOG_DIR/$slug-runs.json" \
+      --slurpfile files "$LOG_DIR/$slug-files.json" \
+      --arg ex "$EXCLUDE_RE" '
+  ($runs[0] | map(.path) | unique) as $ran
+  | $files[0] as $onbranch
+  | [ $wf[0][]
+      | select(.path | test($ex) | not)
+      | select(.path | IN($ran[]) | not)
+      | {id, path, name, state, created, on_branch: (.path | IN($onbranch[]))} ]' \
+  > "$LOG_DIR/$slug-gaps.json"
+
+# Most zero-run workflows are ordinary PR or push workflows. Keep only the ones that are
+# actually scheduled — without this the `reusable-nightly-e2e-*.yaml` workflows in llm-d-infra,
+# which are workflow_call:-only and never produce runs of their own, are all reported as
+# missing nightlies.
+cat > "$LOG_DIR/lastrun.jq" <<'JQ'
+if (.total_count // 0) == 0 then "never"
+else (.workflow_runs[0] | (.run_started_at // .created_at) | tostring | split("T")[0]) end
+JQ
+export LR="$LOG_DIR/lastrun.jq" REPO=$repo
+# A lane registered inside this window has not reached its first scheduled fire yet. Two days
+# covers a daily cron plus the lag before GitHub first honours it.
+export TOO_NEW_BEFORE=$(date -u -v-2d +%Y-%m-%d 2>/dev/null || date -u -d '2 days ago' +%Y-%m-%d)
+
+# One NUL-delimited record per lane rather than `xargs -n 5`. xargs splits on *any* whitespace,
+# so a workflow path containing a space would shift every field of that row and of the rows
+# batched after it, and the misaligned verdicts would look plausible. Same guard as lifetime.sh.
+jq -r '.[] | "\(.id)\t\(.path)\t\(.on_branch)\t\(.state)\t\(.created)"' "$LOG_DIR/$slug-gaps.json" \
+| tr '\n' '\0' \
+| xargs -0 -P 8 -n 1 sh -c '
+    id=$(printf "%s" "$0" | cut -f1)
+    path=$(printf "%s" "$0" | cut -f2)
+    on_branch=$(printf "%s" "$0" | cut -f3)
+    state=$(printf "%s" "$0" | cut -f4)
+    created=$(printf "%s" "$0" | cut -f5)
+    # Last *scheduled* run, not last run: a lane can be dispatched manually after its cron was
+    # removed, which would otherwise hide the gap.
+    last=$(unset GITHUB_TOKEN; gh api \
+      "repos/$REPO/actions/workflows/$id/runs?event=schedule&per_page=1" 2>/dev/null \
+      | jq -r -f "$LR")
+    # A failed call yields empty, and empty is != "never", so it would be taken for a scheduled
+    # lane and land on the STALE arm below — inventing a gap out of a rate limit.
+    if [ -z "$last" ]; then
+      printf "%s\t%s\t%s\t%s\n" "LOOKUP FAILED" "-" "$state" "${path##*/}"; exit 0
+    fi
+    if [ "$last" != "never" ]; then :
+    elif [ "$on_branch" = "true" ] && unset GITHUB_TOKEN && gh api "repos/$REPO/contents/$path" \
+           -H "Accept: application/vnd.github.raw" 2>/dev/null \
+           | grep -qE "^[[:space:]]+schedule:"; then :
+    else exit 0; fi
+    case "$state:$on_branch:$last" in
+      # Registered too recently to have fired. Reporting this as a gap turns every lane added
+      # yesterday into a false alarm. Match the date shape first: a jq "null" would sort above
+      # any real date and mark everything TOO NEW.
+      active:*:never) case "$created" in
+                        20??-??-??) [ "$created" \> "$TOO_NEW_BEFORE" ] \
+                                      && verdict="TOO NEW" || verdict="NEVER RAN" ;;
+                        *)          verdict="NEVER RAN" ;;
+                      esac ;;
+      active:false:*) verdict="REMOVED" ;;     # file deleted, registration lingers
+      active:true:*)  verdict="STALE" ;;       # file present, cron stopped firing
+      *)              verdict="DISABLED" ;;    # incl. GitHub 60-day inactivity auto-off
+    esac
+    printf "%s\t%s\t%s\t%s\n" "$verdict" "$last" "$state" "${path##*/}"' \
+| sort > "$LOG_DIR/$slug-gap-report.tsv"

--- a/.claude/skills/nightly/scripts/joblog.sh
+++ b/.claude/skills/nightly/scripts/joblog.sh
@@ -1,0 +1,14 @@
+# usage: sh joblog.sh <owner/repo> <job_id> — ensures $LOG_DIR/job-<job_id>.log exists
+# --allow-escape-sequences is not optional. Job logs carry ANSI colour, and without the flag
+# `gh` refuses the body and exits 1 with nothing on stdout. Sending that stderr to /dev/null
+# makes a download failure read as a step that produced no output, which is the worst
+# available failure mode, so the download is checked here and the stderr is kept.
+repo=$1; job=$2
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+f="$LOG_DIR/job-$job.log"
+[ -s "$f" ] && exit 0    # a concluded job's log is immutable; never refetch
+
+if ! (unset GITHUB_TOKEN; gh api "repos/$repo/actions/jobs/$job/logs" --allow-escape-sequences) \
+     > "$f" 2>"$LOG_DIR/job-$job.err"; then
+  echo "!! log download failed for job $job:"; cat "$LOG_DIR/job-$job.err"; rm -f "$f"; exit 1
+fi

--- a/.claude/skills/nightly/scripts/jobmeta.sh
+++ b/.claude/skills/nightly/scripts/jobmeta.sh
@@ -1,0 +1,39 @@
+# usage: sh jobmeta.sh <owner/repo> <run_id>
+# Prints one line for the first failing step of the first failing job:
+#   <job_id>\t<step_started>\t<step_completed>\t<step_name>
+# Prints nothing and exits 0 when the run has no failing step — a startup_failure with no jobs
+# is the common case. Exits 1 only when the API itself gave nothing.
+#
+# The response is cached at $LOG_DIR/jobs-<run>.json. errtext.sh, errsig.sh and failed-steps.sh
+# all want the same document for the same run, which on a full pass was three identical
+# paginated calls per red lane.
+repo=$1; run=$2
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+c="$LOG_DIR/jobs-$run.json"
+src=$c
+
+if [ ! -s "$c" ]; then
+  # Stage through a temp: a half-written or empty response left at $c would be treated as a
+  # valid cache by every later caller, and the run would silently attribute to nothing.
+  t="$c.part"
+  (unset GITHUB_TOKEN; gh api "repos/$repo/actions/runs/$run/jobs?per_page=100" \
+     --paginate --slurp) > "$t" 2>/dev/null
+  jq -e '[.[].jobs[]?] | length > 0' "$t" >/dev/null 2>&1 \
+    || { rm -f "$t"; echo "!! jobs API returned no jobs for run $run" >&2; exit 1; }
+  # Keep it only if every job has concluded. A job whose conclusion is null is still running,
+  # and a run can conclude while one lingers, so caching that would freeze "no failing job"
+  # for the rest of the day. Usable now either way.
+  if jq -e '[.[].jobs[]?] | map(.conclusion) | index(null) | not' "$t" >/dev/null 2>&1; then
+    mv "$t" "$c"
+  else
+    src=$t
+  fi
+fi
+
+jq -r '[.[].jobs[]? | select(.conclusion=="failure")][0] as $j
+  # steps[]? — when no job failed $j is null, and bare .steps[] raises
+  # "Cannot iterate over null" before the null check below can run.
+  | ([$j.steps[]? | select(.conclusion=="failure")][0]) as $s
+  | if $j == null or $s == null then empty
+    else "\($j.id)\t\($s.started_at[0:19])\t\($s.completed_at[0:19])\t\($s.name)" end' "$src"
+[ "$src" = "$c" ] || rm -f "$src"

--- a/.claude/skills/nightly/scripts/lanes.jq
+++ b/.claude/skills/nightly/scripts/lanes.jq
@@ -1,0 +1,76 @@
+# One classified row per lane, from a window of scheduled runs. See nightly/report/SKILL.md
+# Phase 1 for what each status means and what it asks the reader to do.
+#
+# A run still in flight has conclusion: null. The window always ends at "now", so this is the
+# common case and every lookup that touches .conclusion needs a guard. {...}[null] raises
+# "Cannot index object with null" *before* a // "?" fallback can apply, so the fallback that
+# looks like it handles this does not. `decisive` is already safe because IN() returns false
+# on null.
+def glyph: if . == null then "?" else                    # ? = still running
+           {success:"P", failure:"F", timed_out:"T", startup_failure:"X",
+            cancelled:"-", skipped:"s"}[.] // "?" end;
+def decisive: IN("success","failure","timed_out","startup_failure");
+def rank: . as $s
+  | ["NEW BREAK","DEGRADED","CHRONIC","UNRELIABLE","NO VERDICT","FLAKY","HEALTHY"]
+  | index($s) // 99;
+
+[ group_by(.path)[]
+  | sort_by(.run_started_at) as $runs
+  # cancelled and skipped are excluded from the denominator: they record no verdict, and
+  # counting them as failures reports a clean lane as 87%.
+  | [$runs[] | select(.conclusion | decisive)] as $d
+  | ($d | length) as $n
+  | ([$d[] | select(.conclusion == "success")] | length) as $p
+  | ([$d[].conclusion] | reverse) as $rev
+  | (([$rev | to_entries[] | select(.value == "success") | .key] | first)
+     // ($rev | length)) as $streak
+  | ([$runs[] | select(.conclusion == "cancelled" or .conclusion == "skipped")]
+     | length) as $nv
+  | (if   $n == 0      then "NO VERDICT"          # only cancelled/skipped runs
+     # One stray failure among seven cancellations must not read as CHRONIC 0/1.
+     elif ($nv * 2) > ($runs | length) then "NO VERDICT"
+     elif $p == $n     then "HEALTHY"
+     elif $streak == 0 then (if ($p * 100 / $n) > 50 then "FLAKY" else "UNRELIABLE" end)
+     elif $p == 0      then "CHRONIC"             # red for the whole window
+     elif ($streak <= 2 and ($n - $streak) >= 3
+           and ($p * 100 / ($n - $streak)) >= 85) then "NEW BREAK"
+     else "DEGRADED" end) as $status
+  | {
+      lane:     ($runs[0].path | sub("^\\.github/workflows/";"") | sub("\\.ya?ml$";"")),
+      # lane has the extension stripped and cannot be fed back to the workflows API.
+      # Keep the real basename for lifetime.sh: .yaml, .yml and .lock.yml all occur.
+      file:     ($runs[0].path | sub("^\\.github/workflows/";"")),
+      name:     $runs[-1].name,
+      runs:     ($runs | length),
+      decisive: $n,
+      passes:   $p,
+      rate:     (if $n > 0 then ($p * 100 / $n | floor) else 0 end),
+      streak:   $streak,
+      seq:      ([$runs[] | .conclusion | glyph] | join("")),
+      last_run: ($runs[-1].run_started_at | split("T")[0]),
+      # The night the current red streak began. "6 runs ago" is not something a reader can act
+      # on; a date is, and it is what lines a lane up against a merge or a cluster change.
+      # Null when the lane is green, and when it is red throughout: the streak then starts at
+      # the window edge, which is an artefact of the window rather than the night it broke.
+      # Phase 3b has the real date for those.
+      broke_on: (if $streak > 0 and $streak < $n
+                 then ($d[-$streak].run_started_at | split("T")[0]) else null end),
+      # Mean wall-clock minutes per failing run, over the whole run rather than the failing
+      # step, so it includes debug collection and teardown. Separates a lane that bails during
+      # standup from one that holds accelerators through a readiness timeout.
+      fail_min: ([$d[] | select(.conclusion != "success")
+                  | ((.updated_at | fromdateiso8601)
+                     - (.run_started_at | fromdateiso8601)) / 60]
+                 | if length == 0 then 0 else (add / length | floor) end),
+      last_fail_id:  ([$d[] | select(.conclusion != "success")] | last | .id),
+      last_fail_url: ([$d[] | select(.conclusion != "success")] | last | .html_url),
+      status: $status,
+      # Every later phase wants the same set, and each one that spelled the predicate out was
+      # one edit away from selecting on .streak alone. A lane can be NO VERDICT and still
+      # carry a nonzero streak — seven cancellations with one older failure among them — and
+      # selecting on .streak pulls it into attribution, clustering and lifetime lookup, where
+      # its stale failure is presented as the current one. Select on .red.
+      red:      ($streak > 0 and $status != "NO VERDICT")
+    }
+]
+| sort_by((.status | rank), -.streak, .lane)

--- a/.claude/skills/nightly/scripts/lifetime.sh
+++ b/.claude/skills/nightly/scripts/lifetime.sh
@@ -1,0 +1,57 @@
+# usage: printf '<owner/repo>\t<workflow file>\t<lane>\n' … | sh lifetime.sh
+# -> streak \t last green \t decisive runs \t first run \t lane, sorted worst first
+#
+# The seven-day window cannot tell a lane that regressed last month from one red since spring
+# from one that has never passed once. They want opposite actions: a revert, a decision about
+# whether to keep the lane, and the lane's author respectively.
+#
+# The workflow file must carry its extension — .yaml, .yml and .lock.yml all occur and the
+# workflows API needs the real basename. per_page=100 is the API maximum and the point: at a
+# smaller page most llm-d lanes come back capped, and a capped streak is indistinguishable
+# from "never passed".
+#
+# One NUL-delimited record per row rather than `xargs -n 3`. xargs splits its input on *any*
+# whitespace, and a lane passed as its display name — "Nightly - Optimized Baseline E2E (GKE
+# GPU)" — becomes eight arguments, so the repo and file for every row after the first are
+# whatever words happened to land in $0 and $1. That failed loudly here only because the stray
+# words were not valid repos; a caller whose lane names merely contain one space would get
+# silently misaligned rows instead.
+tr '\n' '\0' \
+| xargs -0 -P 6 -n 1 sh -c '
+    repo=$(printf "%s" "$0" | cut -f1)
+    file=$(printf "%s" "$0" | cut -f2)
+    lane=$(printf "%s" "$0" | cut -f3)
+    [ -n "$repo" ] && [ -n "$file" ] || exit 0
+    unset GITHUB_TOKEN
+    row=$(gh api "repos/$repo/actions/workflows/$file/runs?event=schedule&per_page=100" \
+            --paginate --slurp 2>/dev/null \
+          | jq -r --arg l "$lane" "
+              # Keep every ?. A wrong or renamed file 404s, and --slurp wraps the error body
+              # rather than the run pages, so an unguarded .workflow_runs[] aborts the row with
+              # \"Cannot iterate over null\" on stderr and prints nothing. The lane then
+              # vanishes from the table rather than reporting that it could not be read.
+              [.[]? | .workflow_runs? // empty] as \$pages
+              | if (\$pages | length) == 0 then \"0\tLOOKUP FAILED\t0\t-\t\(\$l)\"
+                else
+                  # Decisive runs only, matching lanes.jq. Counting cancellations as failures
+                  # inflates a mostly-cancelled lane into the oldest breakage in the fleet, and
+                  # the run count in column 3 is then a count of nothing.
+                  [\$pages[][]
+                    | select(.conclusion == \"success\" or .conclusion == \"failure\"
+                             or .conclusion == \"timed_out\"
+                             or .conclusion == \"startup_failure\")] as \$runs
+                  # A registered lane whose every run so far was cancelled or skipped has no
+                  # streak and no dates; .[-1] on [] is null and raises before any fallback.
+                  | if (\$runs | length) == 0 then \"0\tNO DECISIVE RUN\t0\t-\t\(\$l)\"
+                    else
+                      # Runs come back newest first, so the index of the first success is the
+                      # lifetime failure streak, and no success at all means the whole list.
+                      ((([\$runs[].conclusion] | index(\"success\")) // (\$runs | length)) as \$streak
+                       | \"\(\$streak)\t\([\$runs[] | select(.conclusion == \"success\")] | first
+                             | (.run_started_at[0:10] // \"NEVER PASSED\"))\t\(\$runs | length)\t\(\$runs[-1].run_started_at[0:10])\t\(\$l)\")
+                    end
+                end")
+    # gh failing outright leaves jq with empty stdin, which prints nothing at all.
+    if [ -n "$row" ]; then printf "%s\n" "$row"
+    else printf "0\tLOOKUP FAILED\t0\t-\t%s\n" "$lane"; fi' \
+  | sort -rn

--- a/.claude/skills/nightly/scripts/pull.sh
+++ b/.claude/skills/nightly/scripts/pull.sh
@@ -1,0 +1,29 @@
+# usage: sh pull.sh <failures-tsv>   (fields 1, 2 and 5 are repo, run id, lane name)
+# Writes one $LOG_DIR/err-<run>.txt per row, then concatenates them into $LOG_DIR/errtext.out.
+#
+# xargs cannot drive this: lane names contain spaces, so -n splits mid-name and the run ids
+# pair with the wrong repos. Bounded background loop instead, 6 at a time.
+tsv=$1
+: "${LOG_DIR:?export LOG_DIR before calling this script}"
+: "${NS:?export NS to this scripts directory before calling this script}"
+[ -s "$tsv" ] || { : > "$LOG_DIR/errtext.out"; exit 0; }
+
+n=0
+# A literal tab in IFS, not \t — read takes the characters literally.
+while IFS='	' read -r repo id concl day name wf; do
+  ( out=$(sh "$NS/errtext.sh" "$repo" "$id" 2>&1 | tail -40)
+    printf '########## %s | %s | %s\n%s\n\n' "$name" "$repo" "$id" "$out" \
+      > "$LOG_DIR/err-$id.txt" ) &
+  n=$((n+1)); [ $((n % 6)) -eq 0 ] && wait
+done < "$tsv"
+wait
+
+# Assembled from the TSV, not from `cat $LOG_DIR/err-*.txt`. The glob cannot tell this window's
+# bodies from a previous pass's, so a stale $LOG_DIR silently pads the analysis with lanes that
+# did not fail — 60 files for 26 lanes on one run, two-thirds carried over. $LOG_DIR is now
+# date-scoped, which closes that across days; driving off the TSV also closes it within one.
+: > "$LOG_DIR/errtext.out"
+cut -f2 "$tsv" | while read -r id; do cat "$LOG_DIR/err-$id.txt"; done >> "$LOG_DIR/errtext.out"
+
+echo "$(grep -c '^## NO CAUSE IN WINDOW' "$LOG_DIR/errtext.out" | tr -d ' ') of \
+$(wc -l < "$tsv" | tr -d ' ') bodies named no cause in the step window and fell back to errsig.sh"

--- a/.claude/skills/nightly/scripts/successor.awk
+++ b/.claude/skills/nightly/scripts/successor.awk
@@ -1,0 +1,69 @@
+# usage: awk -f successor.awk -v cur=<stems file> -v ran=<ran paths file> <gap-report.tsv>
+# -> verdict \t lane \t proposed successor(s), for each REMOVED / STALE / NEVER RAN row.
+#
+# REMOVED almost always means renamed, not deleted. The anti-join in gaps.sh cannot see that:
+# the old path stops appearing in runs, the new path is a different row that is running fine,
+# and nothing links them. Reported raw, a single naming migration reads as a fleet of lost
+# lanes.
+#
+# Match on token overlap rather than a prefix. Lanes moved to the -acc- convention both gained
+# and dropped tokens — wide-ep-lws-gke became wide-ep-lws-gke-acc-gpu-vllm-x, but
+# tiered-prefix-cache-cpu-offloading-gke became tiered-prefix-cache-gke-cpu-gpu-vllm-native,
+# which shares no usable prefix.
+#
+# `cur` must already be filtered by $EXCLUDE_RE. Unfiltered, the consolidate-status-<lane>
+# bookkeeping workflows shadow every real lane: each carries the whole lane name plus two
+# tokens, so it wins the overlap and every row proposes a successor that tests nothing.
+
+# nightly and e2e are in every lane name, so they are evidence of nothing.
+function distinctive(w) { return w != "" && w != "nightly" && w != "e2e" }
+
+function label(c, s, tot) {
+  return c " (" s "/" tot ", " ((c in ranstem) ? "ran" : "no run in window") ")  "
+}
+
+BEGIN {
+  FS = "\t"
+  if (cur == "" || ran == "") { print "usage: -v cur=… -v ran=…" > "/dev/stderr"; exit 2 }
+  while ((getline l < cur) > 0) {
+    ncand++; name[ncand] = l
+    n = split(l, a, "-")
+    for (i = 1; i <= n; i++) if (distinctive(a[i])) ctok[ncand SUBSEP a[i]] = 1
+  }
+  close(cur)
+  while ((getline l < ran) > 0) {
+    sub(/^.*\//, "", l); sub(/\.ya?ml$/, "", l); ranstem[l] = 1
+  }
+  close(ran)
+}
+
+$1 != "REMOVED" && $1 != "STALE" && $1 != "NEVER RAN" { next }
+
+{
+  lane = $4; stem = lane; sub(/\.ya?ml$/, "", stem)
+  delete t; total = 0
+  n = split(stem, a, "-")
+  for (i = 1; i <= n; i++)
+    if (distinctive(a[i]) && !(a[i] in t)) { t[a[i]] = 1; total++ }
+
+  # Two candidates, not one: the top score is often a tie and the tie-break is arbitrary. Token
+  # overlap is blind to platform synonyms in particular — …-cpu-offloading-ocp scores equally
+  # against the gke and the ibm lane, and ibm- is the OpenShift-GPU prefix, so the right answer
+  # is the one the score cannot distinguish. Both rows get printed; read both.
+  s1 = -1; s2 = -1; b1 = ""; b2 = ""
+  for (c = 1; c <= ncand; c++) {
+    if (name[c] == stem) continue
+    sc = 0
+    for (k in t) if ((c SUBSEP k) in ctok) sc++
+    if (sc > s1)      { s2 = s1; b2 = b1; s1 = sc; b1 = name[c] }
+    else if (sc > s2) { s2 = sc; b2 = name[c] }
+  }
+
+  # A majority of the old name's distinctive tokens, and never on one token alone — "gke" in
+  # common is not evidence of anything.
+  min = int((total + 1) / 2); if (min < 2) min = 2
+  out = ""
+  if (s1 >= min) out = out label(b1, s1, total)
+  if (s2 >= min) out = out label(b2, s2, total)
+  print $1 "\t" lane "\t" (out == "" ? "NO CANDIDATE — verify by hand" : out)
+}


### PR DESCRIPTION
## What does this PR do?

Corrects the bash and jq in `.claude/skills/nightly/`. `nightly/SKILL.md` triages a failing nightly run and `nightly/report/SKILL.md` produces the weekly fleet report. An agent runs their code blocks verbatim against the GitHub Actions API, so a wrong query returns a wrong report without raising an error. Only `.claude/` changes; CI behavior is unchanged.

**Sub-skill reachability.** Skill discovery scans `.claude/skills/*/SKILL.md` one level deep, so the seven sub-skills at `.claude/skills/nightly/<name>/SKILL.md` were never registered and `Skill(nightly:<x>)` failed. All 13 references in the router and in `.claude/CLAUDE.md` become file paths to Read.

**Data gathering.** `gh run list --limit N` sampled the fleet. `llm-d/llm-d` served 915 scheduled runs over 2026-08-06..12, so `--limit 500` covered under five days, and both `--limit` and the REST endpoint stop at 1000 results while exiting 0. Queries page the REST endpoint with server-side `event` and `created` filters, one day per query, and check each day's returned count against the server's `total_count`. Lane selection moves to `.path` with an exclude list, which keeps the `consolidate-status-*` workflows out of the fleet count. The daily triage window is a rolling 24-hour timestamp; a bare date spanned two nights and doubled every lane.

**Coverage gaps.** A new phase anti-joins the workflow registry against the runs, so a lane that stopped running no longer reads as healthy. Two guards keep the result honest. Lanes registered within the last two days are marked TOO NEW, since they have not reached a first cron. A token-overlap matcher proposes rename successors, because the `-acc-` migration left no shared prefixes to match on. Candidates are filtered by the same exclude list as lane selection; unfiltered, `consolidate-status-<lane>` carries the whole lane name plus two tokens and wins the overlap on every row. The matcher emits its top two candidates, because token overlap ties on platform synonyms and `ibm-` is the OpenShift-GPU prefix.

**Triage on error text.** `Standup` and `Run` each cover several unrelated causes, so classifying on the step name grouped failures wrongly. Step 4b pulls the failing step's output: `errtext.sh` windows the job log on the step's timestamps, then falls back to `errsig.sh`, which greps the whole log through a noise filter, when the window names no cause. Step 4c adds a trailing failure streak and last-green date per lane. Past roughly 15 red lanes, an Explore subagent summarizes the collected error text so it stays out of the conversation context.

**Lane scoring.** Lanes classify on pass rate and trailing streak together. NO VERDICT is a majority-of-cancellations test, and those lanes stay out of attribution and clustering. Lifetime streaks count decisive runs only, and report `NEVER PASSED`, `NO DECISIVE RUN` or `LOOKUP FAILED` rather than dropping a lane out of the table.

**Report content.** Figures the template left as placeholders are computed: fleet summary, lifetime table, failure categories derived from the step-ID prefixes in `reusable-ci-nightly-benchmark.yaml`, per-lane failure cost, and under-merge detection in clustering.

**Shared scripts.** The shell and jq live in `.claude/skills/nightly/scripts/` as 15 files with a `README.md` index, invoked as `sh $NS/<name>.sh`. Both documents need most of the same code, and duplicating it as heredocs let the copies drift: the TOO NEW guard reached one document and not the other, so the weekly report counted every lane added yesterday as a coverage gap. Scripts that fan out feed `xargs` one NUL-delimited record and split the fields with `cut`, because `xargs` splits on any whitespace and a lane display name like `Nightly - Optimized Baseline E2E (GKE GPU)` shifts every field of that row and of the rows batched after it.

**Reference tables.** `llm-d-workload-variant-autoscaler` nightlies run in `llm-d/llm-d`. `llm-d-infra`'s own three nightlies were unmonitored. The `reusable-*-helmfile.yaml` entries in the router and in `.claude/CLAUDE.md` named workflows that do not exist. The schedule matrix is derived from the crons instead of hand-maintained.

## Why is this change needed?

Each defect fails silently. Truncation drops the oldest runs and exits 0; a 7-day query returned 1000 of 1020 runs. A removed lane contributes no runs and reads as healthy. An unregistered sub-skill raises no error, so sessions improvised the missing phase.

## How was this tested?

- [x] Manual testing performed

Every bash and jq block in both files ran in order against `llm-d/llm-d` and `llm-d/llm-d-infra` with exit 0: 278 scheduled runs over 7/7 days for `llm-d`, 42 lanes classified, 5 REMOVED gaps each proposing a running `-acc-` successor, 24 failures attributed to their steps, 27 lifetime rows with no stderr.

Edge cases exercised: the truncation guard on a >1000-run range, which exits 1 with the split-by-hour message; `errtext.sh` on failed runs and on a run with no failing job; a workflow basename the API 404s on; a lane whose every run was cancelled; the Phase 6 window check for equal length and no overlap; an all-green input; an in-flight run; a failed log download; a month-boundary window.

The failure-category taxonomy was cross-checked against the badge commit messages on `gh-pages`.

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines
- [ ] Tests pass locally (`make test`) — n/a, no Makefile in this repo
- [ ] Linters pass (`make lint`) — n/a, no linter covers `.claude/`
- [x] Documentation updated (if applicable)
