### PR TITLE
Add reusable nightly e2e workflow for the AMD ROCm cluster

### DIFF
--- a/.github/workflows/reusable-nightly-e2e-amd.yaml
+++ b/.github/workflows/reusable-nightly-e2e-amd.yaml
@@ -1,0 +1,1022 @@
+name: Reusable - Nightly E2E AMD ROCm (Helmfile)
+
+# Reusable workflow for nightly e2e testing of llm-d guides on the AMD ROCm CI
+# cluster: self-hosted `rocm` runners, amd.com/gpu accelerators. Called by the
+# llm-d/llm-d repo to deploy a guide's stack — via helmfile, or via a custom
+# script for kustomize guides — and run the e2e-validate.sh smoke-test suite.
+#
+# Usage from a caller workflow:
+#
+#   jobs:
+#     nightly:
+#       uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-amd.yaml@main
+#       with:
+#         guide_name: workload-autoscaling
+#         namespace: llm-d-nightly-wva-rocm
+#         helmfile_env: istio
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      # --- Guide configuration ---
+      guide_name:
+        description: 'Guide directory name under guides/ in llm-d/llm-d'
+        required: true
+        type: string
+      guide_path:
+        description: 'Override path to guide directory (default: guides/<guide_name>)'
+        required: false
+        type: string
+        default: ''
+      namespace:
+        description: 'Kubernetes namespace for the deployment'
+        required: true
+        type: string
+      helmfile_env:
+        description: 'Helmfile environment (istio, kgateway, etc.)'
+        required: false
+        type: string
+        default: 'istio'
+      gateway_type:
+        description: 'Gateway provider type (istio, kgateway, agentgateway)'
+        required: false
+        type: string
+        default: 'istio'
+
+      # --- Repository ---
+      llm_d_ref:
+        description: 'Git ref for llm-d/llm-d checkout (default: main)'
+        required: false
+        type: string
+        default: ''
+
+      # --- GPU requirements ---
+      required_gpus:
+        description: 'Minimum GPUs required (0 for simulated)'
+        required: false
+        type: number
+        default: 2
+      recommended_gpus:
+        description: 'Recommended GPUs for scale-up headroom'
+        required: false
+        type: number
+        default: 4
+      gpu_wait_timeout:
+        description: 'Minutes to wait for GPUs to become available (0 = no wait, fail immediately)'
+        required: false
+        type: number
+        default: 0
+      allow_gpu_preemption:
+        description: 'When true, proceed with deployment even if GPUs are unavailable (relies on Kubernetes preemption of lower-priority pods)'
+        required: false
+        type: boolean
+        default: false
+
+      # --- Model & accelerator ---
+      model_id:
+        description: 'Model ID (empty = auto-discover from guide)'
+        required: false
+        type: string
+        default: ''
+      accelerator_type:
+        description: 'Accelerator type (MI355X, MI325X, MI300X)'
+        required: false
+        type: string
+        default: 'MI355X'
+
+      # --- Deployment configuration ---
+      helmfile_args:
+        description: 'Extra args passed to helmfile apply (e.g. --set key=val)'
+        required: false
+        type: string
+        default: ''
+      httproute_file:
+        description: 'HTTPRoute file to apply (empty = skip)'
+        required: false
+        type: string
+        default: ''
+      gateway_host:
+        description: 'Override GATEWAY_HOST for e2e-validate.sh (e.g. svc-name:port). If empty, auto-discovers from Gateway resource.'
+        required: false
+        type: string
+        default: ''
+      install_gateway_provider:
+        description: 'Install gateway provider prerequisites'
+        required: false
+        type: boolean
+        default: false
+      pre_deploy_script:
+        description: 'Script to run before deployment (e.g. slim transforms)'
+        required: false
+        type: string
+        default: ''
+      custom_deploy_script:
+        description: 'Custom deploy script — replaces helmfile apply (for kustomize/helm guides)'
+        required: false
+        type: string
+        default: ''
+      image_override:
+        description: 'Override vLLM container image (e.g. ghcr.io/llm-d/llm-d-rocm-dev:latest)'
+        required: false
+        type: string
+        default: ''
+
+      # --- WVA integration (optional — enables WVA e2e tests) ---
+      deploy_wva:
+        description: 'Deploy WVA guide via make (enables WVA-specific steps)'
+        required: false
+        type: boolean
+        default: false
+      caller_repo:
+        description: 'Caller repo with deploy/install.sh and Go tests (e.g. llm-d/llm-d-workload-variant-autoscaler)'
+        required: false
+        type: string
+        default: ''
+      caller_ref:
+        description: 'Git ref for caller repo'
+        required: false
+        type: string
+        default: 'main'
+      wva_image_tag:
+        description: 'WVA controller image tag'
+        required: false
+        type: string
+        default: 'v0.5.0'
+      test_target:
+        description: 'Make target for Go tests (e.g. test-e2e) — replaces e2e-validate.sh when set'
+        required: false
+        type: string
+        default: ''
+
+      # --- Test configuration ---
+      e2e_validate_args:
+        description: 'Extra args for e2e-validate.sh (e.g. -m model-id)'
+        required: false
+        type: string
+        default: ''
+      pod_wait_timeout:
+        description: 'Timeout for pods to become ready'
+        required: false
+        type: string
+        default: '30m'
+      pod_readiness_delay:
+        description: 'Extra delay after pods are ready (for model loading)'
+        required: false
+        type: number
+        default: 0
+
+      # --- Cleanup ---
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        type: boolean
+        default: false
+
+      # --- PR comment-back (optional) ---
+      pr_number:
+        description: 'PR number to comment on with test results (empty = skip)'
+        required: false
+        type: string
+        default: ''
+      pr_repo:
+        description: 'Repository (owner/repo) for the PR comment (default: llm-d/llm-d)'
+        required: false
+        type: string
+        default: 'llm-d/llm-d'
+
+jobs:
+  nightly-e2e:
+    # Longer than the other providers': this cluster has no persistent model cache,
+    # so every run pulls the model cold before the pod-readiness wait even starts.
+    timeout-minutes: 120
+    runs-on: rocm
+    env:
+      GUIDE_NAME: ${{ inputs.guide_name }}
+      GUIDE_PATH: ${{ inputs.guide_path || format('guides/{0}', inputs.guide_name) }}
+      NAMESPACE: ${{ inputs.namespace }}
+      HELMFILE_ENV: ${{ inputs.helmfile_env }}
+      GATEWAY_TYPE: ${{ inputs.gateway_type }}
+      ACCELERATOR_TYPE: ${{ inputs.accelerator_type }}
+      # WVA-specific env vars (only used when deploy_wva is true)
+      MODEL_ID: ${{ inputs.model_id }}
+      WVA_IMAGE_TAG: ${{ inputs.wva_image_tag }}
+      WVA_NAMESPACE: ${{ format('{0}-system', inputs.namespace) }}
+      WVA_RELEASE_NAME: ${{ format('wva-{0}', inputs.guide_name) }}
+    steps:
+      - name: Checkout llm-d/llm-d
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: llm-d/llm-d
+          ref: ${{ inputs.llm_d_ref || github.ref }}
+
+      - name: Checkout caller repo (WVA)
+        if: inputs.deploy_wva && inputs.caller_repo != ''
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: ${{ inputs.caller_repo }}
+          ref: ${{ inputs.caller_ref }}
+          path: _caller
+
+      - name: Extract Go version from caller repo
+        if: inputs.deploy_wva && inputs.caller_repo != ''
+        run: |
+          if [ -f _caller/go.mod ]; then
+            sed -En 's/^go (.*)$/GO_VERSION=\1/p' _caller/go.mod >> $GITHUB_ENV
+          else
+            echo "GO_VERSION=1.23" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Go
+        if: inputs.deploy_wva && inputs.caller_repo != ''
+        uses: actions/setup-go@v7
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: _caller/go.sum
+
+      - name: Install prerequisites (kubectl, helm, helmfile, yq)
+        run: |
+          # Install make (needed by WVA Go tests)
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
+
+          # Install standard llm-d prerequisites (kubectl, helm, helmfile, yq)
+          ./helpers/client-setup/install-deps.sh
+
+          # Install jq if not present
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
+      - name: Verify cluster access
+        run: |
+          echo "Verifying AMD ROCm cluster access..."
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Cordon unhealthy GPU nodes
+        run: |
+          echo "Checking for unhealthy GPU nodes to cordon..."
+          CORDONED_NODES=""
+          for node in $(kubectl get nodes -o json | jq -r '
+            .items[] | select(
+              ((.status.allocatable["amd.com/gpu"] // "0" | tonumber) > 0) and
+              (.status.conditions[] | select(.type == "Ready") | .status != "True")
+            ) | .metadata.name'); do
+            echo "::warning::Cordoning unhealthy GPU node: $node"
+            kubectl cordon "$node" 2>/dev/null || true
+            CORDONED_NODES="$CORDONED_NODES $node"
+          done
+          echo "NIGHTLY_CORDONED_NODES=$CORDONED_NODES" >> $GITHUB_ENV
+          if [ -z "$CORDONED_NODES" ]; then
+            echo "All GPU nodes are healthy"
+          else
+            echo "Cordoned nodes:$CORDONED_NODES"
+          fi
+
+      - name: Check GPU availability
+        id: gpu-check
+        env:
+          REQUIRED_GPUS: ${{ inputs.required_gpus }}
+          RECOMMENDED_GPUS: ${{ inputs.recommended_gpus }}
+          GPU_WAIT_TIMEOUT: ${{ inputs.gpu_wait_timeout }}
+        run: |
+          echo "Checking GPU availability for nightly e2e ($GUIDE_NAME)..."
+
+          check_gpus() {
+            TOTAL_GPUS=$(kubectl get nodes -o json | \
+              jq '[.items[].status.allocatable["amd.com/gpu"] // "0" | tonumber] | add // 0')
+            ALLOCATED_GPUS=$(kubectl get pods --all-namespaces -o json | \
+              jq '[.items[] | select((.status.phase == "Running" or .status.phase == "Pending") and .metadata.deletionTimestamp == null) | .spec.containers[]?.resources.requests["amd.com/gpu"] // "0" | tonumber] | add // 0')
+            AVAILABLE_GPUS=$((TOTAL_GPUS - ALLOCATED_GPUS))
+          }
+
+          check_gpus
+
+          TOTAL_CPU=$(kubectl get nodes -o json | \
+            jq '[.items[].status.allocatable.cpu // "0" | if endswith("m") then (gsub("m$";"") | tonumber / 1000) else tonumber end] | add | floor')
+          TOTAL_MEM_KI=$(kubectl get nodes -o json | \
+            jq '[.items[].status.allocatable.memory // "0" | gsub("[^0-9]";"") | tonumber] | add')
+          TOTAL_MEM_GI=$((TOTAL_MEM_KI / 1048576))
+
+          NODE_COUNT=$(kubectl get nodes --no-headers | wc -l | tr -d ' ')
+          GPU_NODE_COUNT=$(kubectl get nodes -o json | \
+            jq '[.items[] | select((.status.allocatable["amd.com/gpu"] // "0" | tonumber) > 0)] | length')
+
+          echo "total_gpus=$TOTAL_GPUS" >> $GITHUB_OUTPUT
+          echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+          echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+
+          echo "## GPU Status — Nightly ($GUIDE_NAME on AMD ROCm)" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Total cluster GPUs | $TOTAL_GPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Currently allocated | $ALLOCATED_GPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Available | $AVAILABLE_GPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Required (minimum) | $REQUIRED_GPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Recommended (with scale-up) | $RECOMMENDED_GPUS |" >> $GITHUB_STEP_SUMMARY
+          echo "| Nodes | $NODE_COUNT ($GPU_NODE_COUNT with GPUs) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total CPU | ${TOTAL_CPU} cores |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total Memory | ${TOTAL_MEM_GI} Gi |" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$REQUIRED_GPUS" -eq 0 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**No GPUs required** for this guide (simulated accelerators)" >> $GITHUB_STEP_SUMMARY
+          elif [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+            # Try waiting for GPUs first
+            if [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ]; then
+              DEADLINE=$((SECONDS + GPU_WAIT_TIMEOUT * 60))
+              echo "::notice::Waiting up to ${GPU_WAIT_TIMEOUT}m for GPUs (need $REQUIRED_GPUS, have $AVAILABLE_GPUS)..."
+              while [ $SECONDS -lt $DEADLINE ]; do
+                REMAINING=$(( (DEADLINE - SECONDS) / 60 ))
+                echo "[$(date +%H:%M:%S)] Waiting for GPUs... need $REQUIRED_GPUS, have $AVAILABLE_GPUS (${REMAINING}m remaining)"
+                sleep 120
+                check_gpus
+                if [ "$AVAILABLE_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "[$(date +%H:%M:%S)] GPUs now available: $AVAILABLE_GPUS free"
+                  echo "available_gpus=$AVAILABLE_GPUS" >> $GITHUB_OUTPUT
+                  echo "allocated_gpus=$ALLOCATED_GPUS" >> $GITHUB_OUTPUT
+                  break
+                fi
+              done
+            fi
+            # If still insufficient after waiting, try preemption or fail
+            if [ "$AVAILABLE_GPUS" -lt "$REQUIRED_GPUS" ]; then
+              if [ "${{ inputs.allow_gpu_preemption }}" = "true" ]; then
+                # Count GPU pods with default priority (0) or negative — these can be
+                # preempted by nightly pods deployed with a higher PriorityClass.
+                PREEMPTABLE_GPU_COUNT=$(kubectl get pods --all-namespaces -o json | \
+                  jq '[.items[] | select(
+                    (.spec.containers[]?.resources.limits["amd.com/gpu"] // "0" | tonumber) > 0
+                    and (.spec.priority // 0) <= 0
+                  ) | .spec.containers[]?.resources.limits["amd.com/gpu"] // "0" | tonumber] | add // 0')
+                PREEMPTABLE_POD_COUNT=$(kubectl get pods --all-namespaces -o json | \
+                  jq '[.items[] | select(
+                    (.spec.containers[]?.resources.limits["amd.com/gpu"] // "0" | tonumber) > 0
+                    and (.spec.priority // 0) <= 0
+                  )] | length')
+                POTENTIAL_GPUS=$((AVAILABLE_GPUS + PREEMPTABLE_GPU_COUNT))
+                if [ "$POTENTIAL_GPUS" -ge "$REQUIRED_GPUS" ]; then
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient free GPUs** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS free. Found $PREEMPTABLE_POD_COUNT preemptable GPU pod(s) holding $PREEMPTABLE_GPU_COUNT GPU(s) — proceeding (Kubernetes will preempt as needed)." >> $GITHUB_STEP_SUMMARY
+                  echo "::warning::Insufficient free GPUs ($AVAILABLE_GPUS/$REQUIRED_GPUS) but $PREEMPTABLE_GPU_COUNT preemptable GPUs available (priority <= 0)"
+                else
+                  WAIT_MSG=""
+                  [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS, have $AVAILABLE_GPUS free + $PREEMPTABLE_GPU_COUNT preemptable = $POTENTIAL_GPUS total (not enough)." >> $GITHUB_STEP_SUMMARY
+                  echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS free + $PREEMPTABLE_GPU_COUNT preemptable = $POTENTIAL_GPUS total.${WAIT_MSG}"
+                  exit 1
+                fi
+              else
+                WAIT_MSG=""
+                [ "${GPU_WAIT_TIMEOUT:-0}" -gt 0 ] && WAIT_MSG=" (after waiting ${GPU_WAIT_TIMEOUT}m)"
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "**Insufficient GPUs${WAIT_MSG}** — need $REQUIRED_GPUS but only $AVAILABLE_GPUS available." >> $GITHUB_STEP_SUMMARY
+                echo "::error::Insufficient GPUs: need $REQUIRED_GPUS, have $AVAILABLE_GPUS available${WAIT_MSG}"
+                exit 1
+              fi
+            else
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**GPUs available after waiting** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
+            fi
+          elif [ "$AVAILABLE_GPUS" -lt "$RECOMMENDED_GPUS" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Low GPU headroom** — $AVAILABLE_GPUS available (need $RECOMMENDED_GPUS for scale-up tests)." >> $GITHUB_STEP_SUMMARY
+            echo "::warning::Low GPU headroom: $AVAILABLE_GPUS available, $RECOMMENDED_GPUS recommended"
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**GPUs available** — $AVAILABLE_GPUS GPUs free ($REQUIRED_GPUS required, $RECOMMENDED_GPUS recommended)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Get HF token from cluster secret
+        run: |
+          echo "Reading HF token from cluster secret llm-d-hf-token in default namespace..."
+          if ! kubectl get secret llm-d-hf-token -n default &>/dev/null; then
+            echo "::error::Secret 'llm-d-hf-token' not found in default namespace"
+            exit 1
+          fi
+          HF_TOKEN=$(kubectl get secret llm-d-hf-token -n default -o jsonpath='{.data.HF_TOKEN}' | base64 -d)
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::error::Secret 'llm-d-hf-token' exists but 'HF_TOKEN' key is empty or missing"
+            exit 1
+          fi
+          echo "::add-mask::$HF_TOKEN"
+          echo "HF_TOKEN=$HF_TOKEN" >> $GITHUB_ENV
+          echo "HF token retrieved successfully"
+
+      - name: Clean up previous nightly resources
+        run: |
+          echo "Cleaning up previous nightly resources for $GUIDE_NAME..."
+          echo "  NAMESPACE: $NAMESPACE"
+
+          # Build list of namespaces to clean (add WVA namespace if deploying WVA)
+          NAMESPACES="$NAMESPACE"
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
+            NAMESPACES="$NAMESPACE $WVA_NAMESPACE"
+            echo "  WVA_NAMESPACE: $WVA_NAMESPACE"
+          fi
+
+          for ns in $NAMESPACES; do
+            if kubectl get namespace "$ns" &>/dev/null; then
+              echo "=== Cleaning up namespace: $ns ==="
+
+              # Destroy helmfile releases if helmfile.yaml.gotmpl exists
+              if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+                echo "  Destroying helmfile releases..."
+                cd "$GUIDE_PATH"
+                helmfile destroy -e "$HELMFILE_ENV" --namespace "$ns" --args --ignore-not-found 2>/dev/null || true
+                cd "$GITHUB_WORKSPACE"
+              fi
+
+              # Fallback: uninstall any remaining helm releases
+              for release in $(helm list -n "$ns" -q 2>/dev/null); do
+                echo "  Uninstalling helm release: $release"
+                helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
+              done
+
+              # Delete HTTPRoutes and other resources
+              kubectl delete httproute --all -n "$ns" --ignore-not-found || true
+              kubectl delete gateway --all -n "$ns" --ignore-not-found || true
+
+              kubectl delete pods -n "$ns" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+              echo "  Deleting namespace: $ns"
+              kubectl delete namespace "$ns" --ignore-not-found --timeout=120s || \
+                kubectl delete namespace "$ns" --force --grace-period=0 2>/dev/null || true
+              if kubectl get namespace "$ns" 2>/dev/null | grep -q Terminating; then
+                echo "Warning: namespace $ns still Terminating — clearing finalizers"
+                kubectl get namespace "$ns" -o json | \
+                  jq '.spec.finalizers = []' | \
+                  kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
+              fi
+            else
+              echo "Namespace $ns does not exist, skipping"
+            fi
+          done
+
+          # Clean up cluster-scoped WVA resources from previous nightly
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            echo "Removing cluster-scoped WVA resources for release $WVA_RELEASE_NAME..."
+            kubectl delete clusterrole,clusterrolebinding \
+              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
+              --ignore-not-found || true
+
+            echo "Cleaning up orphaned cluster-scoped WVA resources..."
+            for kind in clusterrole clusterrolebinding; do
+              kubectl get "$kind" -o json 2>/dev/null | \
+                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+                while IFS=$'\t' read -r name ns; do
+                  if [ -n "$ns" ] && ! kubectl get namespace "$ns" &>/dev/null; then
+                    echo "  Deleting orphaned $kind/$name (owning namespace '$ns' no longer exists)"
+                    kubectl delete "$kind" "$name" --ignore-not-found || true
+                  fi
+                done
+            done
+          fi
+
+          # Kustomize-based guides create their cluster-scoped RBAC without Helm
+          # metadata, so neither the label selector nor the release-namespace
+          # annotation above can find it, and deleting the namespace leaves it
+          # behind. Such a guide tags what it creates with the namespace label
+          # below; the subject match after it covers bindings created before the
+          # label existed, or by a guide that does not set it.
+          kubectl delete clusterrolebinding -l "llm-d.ai/nightly-namespace=$NAMESPACE" --ignore-not-found || true
+          for crb in $(kubectl get clusterrolebinding -o json 2>/dev/null | \
+            jq -r --arg ns "$NAMESPACE" '.items[] | select(any(.subjects[]?; .kind == "ServiceAccount" and .namespace == $ns)) | .metadata.name'); do
+            echo "  Deleting clusterrolebinding/$crb (ServiceAccount subject in $NAMESPACE)"
+            kubectl delete clusterrolebinding "$crb" --ignore-not-found || true
+          done
+
+          echo "Pre-cleanup complete"
+
+      - name: Create nightly PriorityClass
+        if: inputs.allow_gpu_preemption && inputs.required_gpus > 0
+        run: |
+          echo "Creating nightly-gpu-critical PriorityClass for GPU preemption..."
+          cat <<'PRIORITY_EOF' | kubectl apply -f -
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          metadata:
+            name: nightly-gpu-critical
+          value: 1000000
+          preemptionPolicy: PreemptLowerPriority
+          globalDefault: false
+          description: "High priority for nightly E2E GPU workloads — preempts default-priority pods"
+          PRIORITY_EOF
+
+      - name: Create namespace and HF token secret
+        run: |
+          echo "Creating namespace $NAMESPACE..."
+          kubectl create namespace "$NAMESPACE" || echo "Namespace already exists"
+
+          echo "Creating HF token secret in $NAMESPACE..."
+          kubectl create secret generic llm-d-hf-token \
+            --from-literal="HF_TOKEN=$HF_TOKEN" \
+            --namespace "$NAMESPACE" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Install gateway provider
+        if: inputs.install_gateway_provider
+        run: |
+          echo "Installing gateway provider dependencies..."
+          cd guides/prereq/gateway-provider
+          ./install-gateway-provider-dependencies.sh
+          helmfile apply -f "${GATEWAY_TYPE}.helmfile.yaml" 2>/dev/null || \
+            helmfile apply -e "${GATEWAY_TYPE}" 2>/dev/null || \
+            echo "::warning::Gateway provider helmfile not found for $GATEWAY_TYPE — may already be installed"
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Wait for gateway control plane
+        if: inputs.install_gateway_provider
+        run: |
+          echo "Waiting for gateway control plane pods..."
+          kubectl wait --for=condition=ready pod \
+            --selector=app.kubernetes.io/managed-by=Helm \
+            --namespace "${GATEWAY_TYPE}-system" \
+            --timeout=300s 2>/dev/null || true
+
+      - name: Override vLLM image
+        if: inputs.image_override != ''
+        run: |
+          set -euo pipefail
+          echo "IMAGE_OVERRIDE=${{ inputs.image_override }}" >> $GITHUB_ENV
+          echo "Overriding vLLM images to: ${{ inputs.image_override }}"
+          VALUES_FILES=$(find "$GUIDE_PATH" -name "values*.yaml")
+          if [ -z "$VALUES_FILES" ]; then
+            echo "::warning::No values*.yaml files found in $GUIDE_PATH — image override will have no effect on values files"
+          else
+            for file in $VALUES_FILES; do
+              echo "Updating vLLM image in ${file}..."
+              # Guard each yq call: only modify if the key exists, otherwise yq creates ghost empty arrays
+              yq e '(select(.decode.containers != null) | .decode.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-rocm"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.prefill.containers != null) | .prefill.containers[].image | select(test("^ghcr\.io/llm-d/llm-d-rocm"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              yq e '(select(.containers != null) | .containers[].image | select(test("^ghcr\.io/llm-d/llm-d-rocm"))) = strenv(IMAGE_OVERRIDE)' -i "$file"
+              sed -E "s/^#([[:space:]]+)priorityClassName/\1priorityClassName/g" -i $file
+            done
+          fi
+        env:
+          IMAGE_OVERRIDE: ${{ inputs.image_override }}
+
+      - name: Apply latest WVA CRDs
+        if: inputs.deploy_wva
+        run: |
+          echo "Applying latest VariantAutoscaling CRD..."
+          kubectl apply -f _caller/charts/workload-variant-autoscaler/crds/
+
+      - name: Run pre-deploy script
+        if: inputs.pre_deploy_script != ''
+        run: |
+          echo "Running pre-deploy script..."
+          ${{ inputs.pre_deploy_script }}
+
+      - name: Deploy WVA guide via make
+        if: inputs.deploy_wva
+        env:
+          ENVIRONMENT: kubernetes
+          LLMD_NS: ${{ inputs.namespace }}
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
+          WELL_LIT_PATH_NAME: ${{ inputs.guide_name }}
+          RELEASE_NAME_POSTFIX: ${{ inputs.guide_name }}
+        run: |
+          echo "Deploying WVA guide on AMD ROCm..."
+          echo "  LLMD_NS: $LLMD_NS"
+          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
+          cd _caller
+          make nightly-deploy-wva-guide
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Deploy guide via helmfile
+        if: inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        run: |
+          echo "Deploying $GUIDE_NAME via helmfile (env: $HELMFILE_ENV)..."
+          cd "$GUIDE_PATH"
+          helmfile apply -e "$HELMFILE_ENV" \
+            --namespace "$NAMESPACE" \
+            --skip-schema-validation \
+            ${{ inputs.helmfile_args }} \
+            | tee /tmp/helmfile-deploy.log
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Deploy guide via custom script
+        if: inputs.custom_deploy_script != '' && !inputs.deploy_wva
+        run: |
+          echo "Deploying $GUIDE_NAME via custom script..."
+          ${{ inputs.custom_deploy_script }}
+
+      - name: Deploy HTTPRoute
+        if: inputs.httproute_file != '' && inputs.custom_deploy_script == '' && !inputs.deploy_wva
+        run: |
+          HTTPROUTE="${GUIDE_PATH}/${{ inputs.httproute_file }}"
+          if [ -f "$HTTPROUTE" ]; then
+            echo "Deploying HTTPRoute from $HTTPROUTE..."
+            kubectl apply -f "$HTTPROUTE" -n "$NAMESPACE"
+          else
+            echo "::warning::HTTPRoute file $HTTPROUTE not found — skipping"
+          fi
+
+      - name: Show deployment status
+        run: |
+          echo "=== Deployments ==="
+          kubectl get deployments -n "$NAMESPACE" || true
+          echo ""
+          echo "=== StatefulSets ==="
+          kubectl get statefulsets -n "$NAMESPACE" || true
+          echo ""
+          echo "=== LeaderWorkerSets ==="
+          kubectl get leaderworkersets -n "$NAMESPACE" 2>/dev/null || true
+          echo ""
+          echo "=== Pods ==="
+          kubectl get pods -n "$NAMESPACE" -o wide || true
+          echo ""
+          echo "=== Services ==="
+          kubectl get svc -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Helm releases ==="
+          helm list -n "$NAMESPACE" || true
+          echo ""
+          echo "=== InferencePools ==="
+          kubectl get inferencepools -n "$NAMESPACE" || true
+          echo ""
+          echo "=== HTTPRoutes ==="
+          kubectl get httproutes -n "$NAMESPACE" || true
+          echo ""
+          echo "=== Gateways ==="
+          kubectl get gateway -n "$NAMESPACE" || true
+
+      # Emit image metadata early so the artifact is available while tests run.
+      # Images are fully resolved after override+deploy — no need to wait for tests.
+      - name: Emit image metadata
+        if: always()
+        env:
+          DEPLOY_WVA: ${{ inputs.deploy_wva && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          METADATA_FILE=/tmp/image-metadata.json
+          SCAN_PATH="${GUIDE_PATH:-llm-d/guides/$GUIDE_NAME}"
+          LLMD_IMAGES='{}'
+          OTHER_IMAGES='{}'
+          if [ -d "$SCAN_PATH" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              name=$(echo "$ref" | sed 's|.*/||' | cut -d: -f1)
+              tag=$(echo "$ref" | sed 's/.*://')
+              if echo "$ref" | grep -q 'ghcr\.io/llm-d/'; then
+                LLMD_IMAGES=$(echo "$LLMD_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              else
+                OTHER_IMAGES=$(echo "$OTHER_IMAGES" | jq --arg k "$name" --arg v "$tag" '. + {($k): $v}')
+              fi
+            done < <(grep -roh '[a-z][a-z0-9.-]*\.io/[a-zA-Z0-9_./-]*:[a-zA-Z0-9._-]*' "$SCAN_PATH" 2>/dev/null | sort -u)
+          fi
+          jq -n \
+            --arg imageOverride "${IMAGE_OVERRIDE:-}" \
+            --arg wvaImageTag "${WVA_IMAGE_TAG:-}" \
+            --arg deployWva "${DEPLOY_WVA:-}" \
+            --arg guideName "$GUIDE_NAME" \
+            --argjson llmdImages "$LLMD_IMAGES" \
+            --argjson otherImages "$OTHER_IMAGES" \
+            '{
+              guideName: $guideName,
+              imageOverride: (if $imageOverride != "" then $imageOverride else null end),
+              wvaImageTag: (if $deployWva == "true" and $wvaImageTag != "" then $wvaImageTag else null end),
+              llmdImages: $llmdImages,
+              otherImages: $otherImages
+            }' > "$METADATA_FILE"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Resolved Images" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          jq . "$METADATA_FILE" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload image metadata
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: image-metadata
+          path: /tmp/image-metadata.json
+          retention-days: 90
+
+      - name: Wait for pods to be ready
+        env:
+          POD_WAIT_TIMEOUT: ${{ inputs.pod_wait_timeout }}
+          POD_READINESS_DELAY: ${{ inputs.pod_readiness_delay }}
+        run: |
+          echo "Waiting for all pods in $NAMESPACE to be ready (timeout: $POD_WAIT_TIMEOUT)..."
+          if ! kubectl wait pod \
+            --for=condition=Ready \
+            --all \
+            -n "$NAMESPACE" \
+            --timeout="$POD_WAIT_TIMEOUT"; then
+            echo "::error::Pods in $NAMESPACE did not become ready within $POD_WAIT_TIMEOUT"
+            echo "--- Pods ---"
+            kubectl get pods -n "$NAMESPACE" -o wide || true
+            echo "--- Describe non-ready pods ---"
+            for pod in $(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              echo "=== Pod: $pod ==="
+              kubectl describe pod "$pod" -n "$NAMESPACE" || true
+              kubectl logs "$pod" -n "$NAMESPACE" --tail=50 || true
+            done
+            exit 1
+          fi
+
+          if [ "$POD_READINESS_DELAY" -gt 0 ]; then
+            echo "Extra readiness delay: ${POD_READINESS_DELAY}s (model loading)..."
+            sleep "$POD_READINESS_DELAY"
+          fi
+
+          # Also wait for WVA namespace pods
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
+            echo "Waiting for WVA pods in $WVA_NAMESPACE..."
+            kubectl wait --for=condition=available --timeout=300s deployment --all -n "$WVA_NAMESPACE" || true
+            kubectl get pods -n "$WVA_NAMESPACE"
+          fi
+
+          echo "All pods in $NAMESPACE are ready"
+          kubectl get pods -n "$NAMESPACE"
+
+      - name: Wait for gateway to be ready
+        if: inputs.install_gateway_provider
+        run: |
+          GATEWAY_NAME=$(kubectl get gateway -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -n "$GATEWAY_NAME" ]; then
+            echo "Waiting for gateway $GATEWAY_NAME to be programmed..."
+            kubectl wait "gateway/$GATEWAY_NAME" \
+              --for=condition=Programmed=True \
+              -n "$NAMESPACE" \
+              --timeout=300s || echo "::warning::Gateway not programmed within timeout"
+            kubectl get gateway -n "$NAMESPACE"
+          else
+            echo "No gateway resource found in $NAMESPACE — skipping wait"
+          fi
+
+      - name: Verify metrics pipeline (WVA)
+        if: inputs.deploy_wva
+        env:
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+        run: |
+          echo "=== Metrics Pipeline Verification ==="
+          echo "Waiting 180s for model to load and metrics to flow..."
+          sleep 180
+
+          echo "--- WVA Controller Logs (last 50 lines) ---"
+          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --tail=50 --all-containers 2>/dev/null || echo "Could not retrieve WVA controller logs"
+
+          echo "--- External Metrics API ---"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.resources[].name' 2>/dev/null || echo "External metrics API not responding"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/wva_desired_replicas" 2>/dev/null | jq '.' || echo "wva_desired_replicas metric not available yet"
+
+          echo "=== Metrics Pipeline Verification Complete ==="
+
+      - name: Install Go dependencies (WVA)
+        if: inputs.deploy_wva && inputs.caller_repo != ''
+        run: |
+          cd _caller
+          go mod download
+
+      - name: Run WVA E2E validation
+        if: inputs.deploy_wva && inputs.test_target != ''
+        env:
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+          LLMD_NAMESPACE: ${{ inputs.namespace }}
+          GATEWAY_NAME: infra-${{ inputs.guide_name }}-inference-gateway-istio
+          DEPLOYMENT: ms-${{ inputs.guide_name }}-llm-d-modelservice-decode
+          WVA_RELEASE_NAME: ${{ env.WVA_RELEASE_NAME }}
+          EPP_SERVICE_NAME: gaie-${{ inputs.guide_name }}-epp
+          ENVIRONMENT: kubernetes
+          CONTROLLER_INSTANCE: ${{ env.WVA_RELEASE_NAME }}
+        run: |
+          echo "Running WVA E2E validation (${{ inputs.test_target }}) on AMD ROCm..."
+          echo "  CONTROLLER_NAMESPACE: $CONTROLLER_NAMESPACE"
+          echo "  LLMD_NAMESPACE: $LLMD_NAMESPACE"
+          echo "  DEPLOYMENT: $DEPLOYMENT"
+          echo "  EPP_SERVICE_NAME: $EPP_SERVICE_NAME"
+          echo "  MODEL_ID: $MODEL_ID"
+          echo "  ENVIRONMENT: $ENVIRONMENT"
+          echo "  CONTROLLER_INSTANCE: $CONTROLLER_INSTANCE"
+          cd _caller
+          make ${{ inputs.test_target }}
+
+      - name: Diagnostic dump (WVA, on failure)
+        if: failure() && inputs.deploy_wva
+        env:
+          CONTROLLER_NAMESPACE: ${{ env.WVA_NAMESPACE }}
+        run: |
+          echo "=== Post-Failure Diagnostic Dump ==="
+
+          echo "--- VariantAutoscaling Full Status ---"
+          kubectl describe variantautoscaling -n "$NAMESPACE" 2>/dev/null || echo "No VA found"
+
+          echo "--- WVA Controller Logs (full) ---"
+          kubectl logs -n "$CONTROLLER_NAMESPACE" -l app.kubernetes.io/name=workload-variant-autoscaler --all-containers --tail=200 2>/dev/null || echo "Could not retrieve WVA controller logs"
+
+          echo "--- External Metrics API ---"
+          kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" 2>/dev/null | jq '.' || echo "External metrics API not responding"
+
+          echo "--- All Pods in Test Namespaces ---"
+          kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
+          kubectl get pods -n "$CONTROLLER_NAMESPACE" -o wide 2>/dev/null || true
+
+          echo "=== Diagnostic Dump Complete ==="
+
+      - name: Run E2E validation
+        if: "!inputs.deploy_wva"
+        env:
+          GATEWAY_HOST: ${{ inputs.gateway_host }}
+        run: |
+          echo "Running E2E validation for $GUIDE_NAME on AMD ROCm..."
+          cd .github/scripts/e2e
+          ./e2e-validate.sh -n "$NAMESPACE" ${{ inputs.e2e_validate_args }}
+
+      - name: Nightly summary
+        if: always()
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Nightly E2E Results — $GUIDE_NAME (AMD ROCm)" >> $GITHUB_STEP_SUMMARY
+          echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Guide | $GUIDE_NAME |" >> $GITHUB_STEP_SUMMARY
+          echo "| Platform | AMD ROCm CI |" >> $GITHUB_STEP_SUMMARY
+          echo "| Namespace | $NAMESPACE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Helmfile Env | $HELMFILE_ENV |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gateway Type | $GATEWAY_TYPE |" >> $GITHUB_STEP_SUMMARY
+          echo "| Accelerator | $ACCELERATOR_TYPE |" >> $GITHUB_STEP_SUMMARY
+          echo "| llm-d Ref | ${{ inputs.llm_d_ref }} |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            echo "| Caller Repo | ${{ inputs.caller_repo }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Model | $MODEL_ID |" >> $GITHUB_STEP_SUMMARY
+            echo "| Test Target | ${{ inputs.test_target }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Comment on PR
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN || github.token }}
+          script: |
+            const status = '${{ job.status }}';
+            const passed = status === 'success';
+            const icon = passed ? ':white_check_mark:' : ':x:';
+            const label = passed ? 'Passed' : 'Failed';
+            const guideName = '${{ inputs.guide_name }}';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = '${{ github.sha }}'.substring(0, 7);
+
+            const [prOwner, prRepo] = '${{ inputs.pr_repo }}'.split('/');
+            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+
+            const body = [
+              `### Nightly E2E Result: \`${guideName}\` (AMD ROCm)`,
+              '',
+              '| | |',
+              '|---|---|',
+              `| Result | ${icon} **${label}** |`,
+              `| Guide | \`${guideName}\` |`,
+              `| Run | [View logs](${runUrl}) |`,
+              `| Ref | \`${sha}\` |`,
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: prNumber,
+                body,
+              });
+            } catch (err) {
+              core.warning(`Failed to comment on PR #${prNumber}: ${err.message}`);
+            }
+
+      - name: Collect pod logs
+        if: always()
+        run: |
+          mkdir -p /tmp/pod-logs-$GUIDE_NAME
+          echo "Collecting pod logs from $NAMESPACE..."
+          for pod in $(kubectl get pods -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+            kubectl logs --all-containers=true -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}.log" 2>&1 || true
+            kubectl describe pod -n "$NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/${pod}-describe.log" 2>&1 || true
+          done
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && kubectl get namespace "$WVA_NAMESPACE" &>/dev/null; then
+            echo "Collecting pod logs from $WVA_NAMESPACE..."
+            for pod in $(kubectl get pods -n "$WVA_NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+              kubectl logs --all-containers=true -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}.log" 2>&1 || true
+              kubectl describe pod -n "$WVA_NAMESPACE" "$pod" > "/tmp/pod-logs-$GUIDE_NAME/wva-${pod}-describe.log" 2>&1 || true
+            done
+          fi
+          cp /tmp/helmfile-deploy.log "/tmp/pod-logs-$GUIDE_NAME/" 2>/dev/null || true
+
+      - name: Upload pod logs
+        uses: actions/upload-artifact@v7.0.1
+        if: always()
+        with:
+          name: nightly-pod-logs-${{ inputs.guide_name }}-amd
+          path: /tmp/pod-logs-${{ inputs.guide_name }}
+          retention-days: 7
+
+      - name: Cleanup infrastructure
+        if: always() && inputs.skip_cleanup == false
+        run: |
+          echo "Cleaning up nightly test infrastructure for $GUIDE_NAME..."
+
+          # Uninstall WVA helm release first
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            helm uninstall "$WVA_RELEASE_NAME" -n "$WVA_NAMESPACE" --ignore-not-found --wait --timeout 60s || true
+          fi
+
+          # Destroy helmfile releases
+          if [ -f "$GUIDE_PATH/helmfile.yaml.gotmpl" ]; then
+            echo "Destroying helmfile releases..."
+            cd "$GUIDE_PATH"
+            helmfile destroy -e "$HELMFILE_ENV" --namespace "$NAMESPACE" 2>/dev/null || true
+            cd "$GITHUB_WORKSPACE"
+          fi
+
+          # Delete HTTPRoute
+          if [ -n "${{ inputs.httproute_file }}" ] && [ -f "$GUIDE_PATH/${{ inputs.httproute_file }}" ]; then
+            kubectl delete -f "$GUIDE_PATH/${{ inputs.httproute_file }}" -n "$NAMESPACE" --ignore-not-found || true
+          fi
+
+          # Fallback: uninstall remaining helm releases in all namespaces
+          for ns in "$NAMESPACE" ${WVA_NAMESPACE:+"$WVA_NAMESPACE"}; do
+            for release in $(helm list -n "$ns" -q 2>/dev/null); do
+              echo "  Uninstalling release: $release in $ns"
+              helm uninstall "$release" -n "$ns" --ignore-not-found --wait --timeout 60s || true
+            done
+          done
+
+          # Delete namespaces — force-delete stuck pods first, then force namespace if graceful times out
+          kubectl delete pods -n "$NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+          echo "Deleting namespace $NAMESPACE..."
+          kubectl delete namespace "$NAMESPACE" --ignore-not-found --timeout=120s || \
+            kubectl delete namespace "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          if kubectl get namespace "$NAMESPACE" 2>/dev/null | grep -q Terminating; then
+            echo "Warning: namespace $NAMESPACE still Terminating — clearing finalizers"
+            kubectl get namespace "$NAMESPACE" -o json | \
+              jq '.spec.finalizers = []' | \
+              kubectl replace --raw "/api/v1/namespaces/$NAMESPACE/finalize" -f - 2>/dev/null || true
+          fi
+          if [ "${{ inputs.deploy_wva }}" = "true" ] && [ -n "$WVA_NAMESPACE" ]; then
+            kubectl delete pods -n "$WVA_NAMESPACE" --all --force --grace-period=0 --wait=false 2>/dev/null || true
+            echo "Deleting namespace $WVA_NAMESPACE..."
+            kubectl delete namespace "$WVA_NAMESPACE" --ignore-not-found --timeout=120s || \
+              kubectl delete namespace "$WVA_NAMESPACE" --force --grace-period=0 2>/dev/null || true
+            if kubectl get namespace "$WVA_NAMESPACE" 2>/dev/null | grep -q Terminating; then
+              echo "Warning: namespace $WVA_NAMESPACE still Terminating — clearing finalizers"
+              kubectl get namespace "$WVA_NAMESPACE" -o json | \
+                jq '.spec.finalizers = []' | \
+                kubectl replace --raw "/api/v1/namespaces/$WVA_NAMESPACE/finalize" -f - 2>/dev/null || true
+            fi
+          fi
+          # WVA install.sh creates a monitoring namespace for kube-prometheus-stack.
+          # Clean it up to prevent stale DaemonSet pods from blocking future runs.
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            MONITORING_NS="workload-variant-autoscaler-monitoring"
+            if kubectl get namespace "$MONITORING_NS" &>/dev/null; then
+              echo "Cleaning up WVA monitoring namespace $MONITORING_NS..."
+              helm uninstall kube-prometheus-stack -n "$MONITORING_NS" --ignore-not-found 2>/dev/null || true
+              helm uninstall prometheus-adapter -n "$MONITORING_NS" --ignore-not-found 2>/dev/null || true
+              kubectl delete namespace "$MONITORING_NS" --ignore-not-found --timeout=120s || true
+            fi
+          fi
+
+          # Clean up cluster-scoped WVA resources
+          if [ "${{ inputs.deploy_wva }}" = "true" ]; then
+            kubectl delete clusterrole,clusterrolebinding \
+              -l app.kubernetes.io/name=workload-variant-autoscaler,app.kubernetes.io/instance="$WVA_RELEASE_NAME" \
+              --ignore-not-found || true
+
+            for kind in clusterrole clusterrolebinding; do
+              kubectl get "$kind" -o json 2>/dev/null | \
+                jq -r '.items[] | select(.metadata.name | contains("workload-variant-autoscaler")) | "\(.metadata.name)\t\(.metadata.annotations["meta.helm.sh/release-namespace"] // "")"' 2>/dev/null | \
+                while IFS=$'\t' read -r name ns; do
+                  if [ "$ns" = "$NAMESPACE" ] || [ "$ns" = "$WVA_NAMESPACE" ]; then
+                    echo "  Deleting $kind/$name (owned by nightly namespace '$ns')"
+                    kubectl delete "$kind" "$name" --ignore-not-found || true
+                  fi
+                done
+            done
+          fi
+
+          # Same sweep as the pre-cleanup step: catch the cluster-scoped bindings a
+          # kustomize guide leaves behind, by the namespace label it tags them with
+          # and then by any remaining ServiceAccount subject in this namespace.
+          kubectl delete clusterrolebinding -l "llm-d.ai/nightly-namespace=$NAMESPACE" --ignore-not-found || true
+          for crb in $(kubectl get clusterrolebinding -o json 2>/dev/null | \
+            jq -r --arg ns "$NAMESPACE" '.items[] | select(any(.subjects[]?; .kind == "ServiceAccount" and .namespace == $ns)) | .metadata.name'); do
+            echo "  Deleting clusterrolebinding/$crb (ServiceAccount subject in $NAMESPACE)"
+            kubectl delete clusterrolebinding "$crb" --ignore-not-found || true
+          done
+
+          echo "Nightly cleanup complete"
+
+      - name: Uncordon nodes cordoned by this run
+        if: always()
+        run: |
+          if [ -n "$NIGHTLY_CORDONED_NODES" ]; then
+            echo "Uncordoning nodes that were cordoned by this nightly run..."
+            for node in $NIGHTLY_CORDONED_NODES; do
+              echo "  Uncordoning $node"
+              kubectl uncordon "$node" 2>/dev/null || true
+            done
+          fi


### PR DESCRIPTION
## Summary

Adds `reusable-nightly-e2e-amd.yaml`, a sibling of the existing CKS and XPU nightly reusables aimed at the AMD ROCm CI cluster. It carries the same interface as its siblings - `guide_name`, `namespace`, `custom_deploy_script`, `gateway_host`, GPU budget inputs, `e2e_validate_args` - so callers in `llm-d` look the same regardless of accelerator.

The AMD specifics are the self-hosted `rocm` runner, `amd.com/gpu` resource accounting and MI355X capacity checks, and an image override that matches `llm-d-rocm` instead of `llm-d-cuda`.

This is purely additive. No existing workflow is modified, and nothing invokes it until a caller lands in `llm-d`.

## Test plan

Rehearsed by hand on the MI355X cluster, running each step in the order this workflow runs it — pre-cleanup, namespace and HF token secret, deploy script, pod wait, `e2e-validate.sh`, final cleanup - against the AMD workload-autoscaling guide that will be the first caller.

- Deploy and validation both succeeded; all 10 `e2e-validate.sh` iterations passed through the EPP.
- The RBAC sweep removed all four namespace-scoped bindings the guide creates; the subject-only pass missed one whose subject lives elsewhere, which is what motivated adding the label pass.
- The four AMD nightlies already sharing the cluster were unaffected throughout, and GPU usage returned to its baseline after teardown.

`actionlint` is clean apart from the pre-existing unknown-runner-label warning for `rocm`, which the XPU reusable also carries.
