### PR TITLE
feat(nightly): add cluster_config and tasks inputs for agentic eval harnesses

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -142,7 +142,7 @@ on:
         default: 'false'
         type: 'string'
       harness:
-        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "eval-containers", "nop")'
         required: false
         default: 'inference-perf'
         type: 'string'
@@ -156,6 +156,16 @@ on:
         required: false
         default: 'true'
         type: string
+      cluster_config:
+        description: 'Cluster-config file supplying target-cluster values (storage class, service account, runAsUser). Relative to the llm-d-benchmark checkout. Empty means the scenario values are used as-is.'
+        required: false
+        default: ''
+        type: 'string'
+      tasks:
+        description: 'Number of parallel harness tasks ("-j"). Empty means the harness default. Used by agentic eval harnesses that fan out one pod per task.'
+        required: false
+        default: ''
+        type: 'string'
       tpu_topology:
         description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
         required: false
@@ -375,6 +385,8 @@ jobs:
       LLMDBENCH_MONITORING_ENABLED: ${{ inputs.monitoring_enabled || 'true' }}
       LLMDBENCH_CICD_HARNESS: ${{ inputs.harness || 'inference-perf' }}
       LLMDBENCH_CICD_WORKLOAD: ${{ inputs.workload || 'sanity_random.yaml' }}
+      LLMDBENCH_CICD_CLUSTER_CONFIG: ${{ inputs.cluster_config }}
+      LLMDBENCH_CICD_TASKS: ${{ inputs.tasks }}
       LLMDBENCH_CICD_PRIORITY_CLASS: nightly-llm-d-cicd-critical
       LLMDBENCH_CICD_PERSISTENT_MODEL: ${{ inputs.persistent_model || 'false' }}
       LLMDBENCH_CICD_DEEP_CLEANING: ${{ inputs.deep_cleaning || 'false' }}
@@ -963,6 +975,20 @@ jobs:
             export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--kustomize-deploy-timeout $LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT --modelservice-deploy-timeout $LLMDBENCH_CICD_MODELSERVICE_STANDUP_TIMEOUT --standalone-deploy-timeout $LLMDBENCH_CICD_STANDALONE_STANDUP_TIMEOUT $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
           fi
           export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--wait-timeout $LLMDBENCH_CICD_RUN_WAIT_TIMEOUT --pvc-bind-timeout $LLMDBENCH_CICD_RUN_PVC_BIND_TIMEOUT --data-access-timeout $LLMDBENCH_CICD_DATA_ACCESS_TIMEOUT $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
+
+          # Cluster-config supplies target-cluster values (storage class, service
+          # account, runAsUser) that cluster-generic scenarios leave unset. Applies
+          # to both standup and run so the two agree on the same overrides.
+          if [[ -n "$LLMDBENCH_CICD_CLUSTER_CONFIG" ]]; then
+            export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--cluster-config $LLMDBENCH_CICD_CLUSTER_CONFIG $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
+            export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--cluster-config $LLMDBENCH_CICD_CLUSTER_CONFIG $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
+          fi
+
+          # "-j" fans the harness out into N parallel task pods. Only meaningful on
+          # run; harnesses that ignore parallelism are unaffected when this is empty.
+          if [[ -n "$LLMDBENCH_CICD_TASKS" ]]; then
+            export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="-j $LLMDBENCH_CICD_TASKS $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
+          fi
           if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
             export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--model $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
           fi


### PR DESCRIPTION
## What does this PR do?

Adds two optional inputs to `reusable-ci-nightly-benchmark.yaml`:

- **`cluster_config`** — path to a cluster-config file, threaded to `--cluster-config`
  on **both** `standup` and `run` so the two phases agree on the same overrides.
- **`tasks`** — parallel harness task count, threaded to `-j` on `run`.

Both go through the existing `LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD` /
`LLMDBENCH_EXTRA_RUN_OPERATION_CMD` extension points, in the same idiom as the
surrounding timeout flags.

Also adds `"eval-containers"` to the `harness` input's **description**. That
input is a free-form string passed directly to `--harness`, so this is a docs
fix only — no validation exists or changes.

## Why is this change needed?

The `eval-containers` agentic benchmarks in `llm-d-benchmark` need both knobs:

- Eval scenarios are written **cluster-generic**. The target cluster's storage
  class, service account and `runAsUser` come from a cluster-config file rather
  than being baked into the scenario, so `--cluster-config` is how a caller
  points a generic scenario at a real cluster.
- The eval harness fans out **one task pod per unit of work**, and that count has
  to track the served model's replica count, so `-j` must be settable per caller.

Neither is reachable through this engine today, which blocks driving an agentic
eval through the standard nightly path.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

**Backward compatibility — the main risk, since all nightlies share this engine.**
Both inputs default to `''`, and an empty value appends nothing. I simulated the
command construction with and without them; for a caller that passes neither, the
resulting command line is **byte-identical** to before:

```
existing nightly (defaults)  standup:[]
                             run:    [--wait-timeout 3600 --pvc-bind-timeout 600 --data-access-timeout 300 ]

eval caller                  standup:[--cluster-config .../openshift-pokprod.yaml ]
                             run:    [-j 1 --cluster-config .../openshift-pokprod.yaml --wait-timeout 3600 ... ]
```

Also verified:

- **`actionlint`**: 74 shellcheck findings before the change, 74 after — **delta 0**.
  All are pre-existing in this file; the added shell quotes its variables.
- **`pre-commit`**: all hooks pass on the changed file (`check-yaml`,
  `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`, …).
- **The flags are real and accepted**: `llmdbenchmark run --help` confirms
  `-j/--parallelism` and `--cluster-config` (the latter on `standup` too), and a
  `--dry-run` invocation with the exact eval-caller flag combination parsed
  cleanly (`Success: 39, Errors: 0`, no unrecognized-argument errors).

Not exercised: a live nightly run, which needs cluster credentials.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`) — no Makefile in this repo; `pre-commit` run instead
- [x] Linters pass (`make lint`) — `actionlint` + `pre-commit`, delta 0 vs. main
- [x] Documentation updated (if applicable) — input descriptions

## Related Issues

Companion to llm-d/llm-d#2336, which adds the nightly cron for the
`eval-containers` regression test. These two are intended to be reviewed
together.
